### PR TITLE
Fix print events and code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 **/settings/Mainnet.toml
 **/settings/Testnet.toml
+.cache/
 .requirements/
 history.txt

--- a/tests/base-dao.test.ts
+++ b/tests/base-dao.test.ts
@@ -1,6 +1,6 @@
 import { Account, assertEquals, Clarinet, Chain } from "../utils/deps.ts";
 import { BaseDao } from "../models/base-dao.model.ts";
-import { BASE_DAO, EXTENSIONS, PROPOSALS } from "../utils/common.ts";
+import { ADDRESS, BASE_DAO, EXTENSIONS, PROPOSALS } from "../utils/common.ts";
 
 // Extensions
 
@@ -216,21 +216,21 @@ Clarinet.test({
     receipts[0].result.expectOk().expectBool(true);
 
     const expectedPrintEvents = [
-      '{event: "execute", proposal: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.ccip012-bootstrap}',
-      '{enabled: true, event: "extension", extension: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.ccd001-direct-execute}',
-      '{enabled: true, event: "extension", extension: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.ccd002-treasury-mia}',
-      '{enabled: true, event: "extension", extension: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.ccd002-treasury-nyc}',
-      '"CityCoins DAO has risen! Our mission is to empower people to take ownership in their city by transforming citizens into stakeholders with the ability to fund, build, and vote on meaningful upgrades to their communities."',
+      `{event: "execute", proposal: ${ADDRESS}.ccip012-bootstrap}`,
+      `{enabled: true, event: "extension", extension: ${ADDRESS}.ccd001-direct-execute}`,
+      `{enabled: true, event: "extension", extension: ${ADDRESS}.ccd002-treasury-mia}`,
+      `{enabled: true, event: "extension", extension: ${ADDRESS}.ccd002-treasury-nyc}`,
     ];
-    const brokenReceiptEvent = receipts[0].events[4].contract_event.value;
-    const brokenPrintEvent = expectedPrintEvents[4];
     for (const event of expectedPrintEvents) {
-      if (event === brokenPrintEvent) {
-        assertEquals(brokenReceiptEvent, event);
-        continue;
-      }
       receipts[0].events.expectPrintEvent(BASE_DAO, event);
     }
+
+    receipts[0].events
+      .slice(-1)
+      .expectPrintEvent(
+        PROPOSALS.CCIP_012,
+        '"CityCoins DAO has risen! Our mission is to empower people to take ownership in their city by transforming citizens into stakeholders with the ability to fund, build, and vote on meaningful upgrades to their communities."'
+      );
   },
 });
 

--- a/tests/base-dao.test.ts
+++ b/tests/base-dao.test.ts
@@ -6,7 +6,7 @@ import { BASE_DAO, EXTENSIONS, PROPOSALS } from "../utils/common.ts";
 
 Clarinet.test({
   name: "base-dao: is-extension() succeeds and returns false with unrecognized extension",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("deployer")!;
@@ -29,7 +29,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: is-extension() succeeds and returns true for active extensions",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("deployer")!;
@@ -53,7 +53,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: set-extension() fails if caller is not DAO or extension",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("wallet_1")!;
@@ -74,7 +74,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: set-extensions() fails if caller is not DAO or extension",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("wallet_1")!;
@@ -99,7 +99,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: executed-at() succeeds and returns the block height the proposal was executed",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("deployer")!;
@@ -122,7 +122,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: executed-at() succeeds and returns none with unrecognized proposal",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("deployer")!;
@@ -143,7 +143,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: execute() fails if caller is not DAO or extension",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("deployer")!;
@@ -163,7 +163,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: construct() fails when initializing the DAO with bootstrap proposal a second time",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("deployer")!;
@@ -183,7 +183,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: construct() fails when called by an account that is not the deployer",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("wallet_1")!;
@@ -201,7 +201,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: construct() succeeds when initializing the DAO with bootstrap proposal",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("deployer")!;
@@ -238,7 +238,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "base-dao: request-extension-callback() fails if caller is not an extension",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const baseDao = new BaseDao();
     const sender = accounts.get("deployer")!;

--- a/tests/extensions/ccd001-direct-execute.test.ts
+++ b/tests/extensions/ccd001-direct-execute.test.ts
@@ -1,5 +1,5 @@
 import { Account, assertEquals, Clarinet, Chain } from "../../utils/deps.ts";
-import { EXTENSIONS, PROPOSALS } from "../../utils/common.ts";
+import { PROPOSALS } from "../../utils/common.ts";
 import { CCD001DirectExecute } from "../../models/extensions/ccd001-direct-execute.model.ts";
 
 // Authorization check

--- a/tests/extensions/ccd001-direct-execute.test.ts
+++ b/tests/extensions/ccd001-direct-execute.test.ts
@@ -6,7 +6,7 @@ import { CCD001DirectExecute } from "../../models/extensions/ccd001-direct-execu
 
 Clarinet.test({
   name: "ccd001-direct-execute: is-dao-or-extenion() fails when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd001DirectExecute = new CCD001DirectExecute();
     const sender = accounts.get("deployer")!;
@@ -28,7 +28,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "ccd001-direct-execute: set-sunset-block-height() fails when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd001DirectExecute = new CCD001DirectExecute();
     const sender = accounts.get("deployer")!;
@@ -48,7 +48,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "ccd001-direct-execute: set-approver() fails when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd001DirectExecute = new CCD001DirectExecute();
     const sender = accounts.get("deployer")!;
@@ -69,7 +69,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "ccd001-direct-execute: set-signals-required() fails when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd001DirectExecute = new CCD001DirectExecute();
     const sender = accounts.get("deployer")!;
@@ -91,7 +91,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "ccd001-direct-execute: is-approver() returns false if approver is not in map",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd001DirectExecute = new CCD001DirectExecute();
     const sender = accounts.get("deployer")!;
@@ -113,7 +113,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "ccd001-direct-execute: has-signalled() returns false if approver is not in map",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd001DirectExecute = new CCD001DirectExecute();
     const sender = accounts.get("deployer")!;
@@ -139,7 +139,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "ccd001-direct-execute: get-signals-required() returns required signals variable",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd001DirectExecute = new CCD001DirectExecute();
     const sender = accounts.get("deployer")!;
@@ -160,7 +160,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "ccd001-direct-execute: direct-execute() fails if sender is not an approver",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd001DirectExecute = new CCD001DirectExecute();
     const sender = accounts.get("deployer")!;
@@ -186,7 +186,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "ccd001-direct-execute: callback() succeeds when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd001DirectExecute = new CCD001DirectExecute();
     const sender = accounts.get("deployer")!;

--- a/tests/extensions/ccd002-treasury.test.ts
+++ b/tests/extensions/ccd002-treasury.test.ts
@@ -1,6 +1,6 @@
 import { Account, assertEquals, Clarinet, Chain } from "../../utils/deps.ts";
-import { CCD002Treasury } from "../../models/extensions/ccd002-treasury.model.ts";
 import { EXTENSIONS, EXTERNAL } from "../../utils/common.ts";
+import { CCD002Treasury } from "../../models/extensions/ccd002-treasury.model.ts";
 
 // Authorization check
 

--- a/tests/extensions/ccd002-treasury.test.ts
+++ b/tests/extensions/ccd002-treasury.test.ts
@@ -6,7 +6,7 @@ import { EXTENSIONS, EXTERNAL } from "../../utils/common.ts";
 
 Clarinet.test({
   name: "ccd002-treasury: is-dao-or-extenion() fails when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd002Treasury = new CCD002Treasury();
     const sender = accounts.get("deployer")!;
@@ -29,7 +29,7 @@ Clarinet.test({
 // ccd002-treasury: set-allowed() fails when called directly
 Clarinet.test({
   name: "ccd002-treasury: set-allowed() fails when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd002Treasury = new CCD002Treasury();
     const sender = accounts.get("deployer")!;
@@ -55,7 +55,7 @@ Clarinet.test({
 // ccd002-treasury: set-allowed-list() fails when called directly
 Clarinet.test({
   name: "ccd002-treasury: set-allowed-list() fails when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd002Treasury = new CCD002Treasury();
     const sender = accounts.get("deployer")!;
@@ -90,7 +90,7 @@ Clarinet.test({
 // ccd002-treasury: deposit-stx() succeeds and transfers STX to the vault
 Clarinet.test({
   name: "ccd002-treasury: deposit-stx() succeeds and transfers STX to the vault",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd002Treasury = new CCD002Treasury();
     const sender = accounts.get("deployer")!;
@@ -125,7 +125,7 @@ Clarinet.test({
 // ccd002-treasury: withdraw-stx() fails when called directly
 Clarinet.test({
   name: "ccd002-treasury: withdraw-stx() fails when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd002Treasury = new CCD002Treasury();
     const sender = accounts.get("deployer")!;
@@ -151,7 +151,7 @@ Clarinet.test({
 /* need MIA token contract first
 Clarinet.test({
   name: "ccd002-treasury: withdraw-ft() fails when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd002Treasury = new CCD002Treasury();
     const sender = accounts.get("deployer")!;
@@ -183,7 +183,7 @@ Clarinet.test({
 // ccd002-treasury: is-allowed() succeeds and returns false if asset is not in map
 Clarinet.test({
   name: "ccd002-treasury: is-allowed() succeeds and returns false if asset is not in map",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd002Treasury = new CCD002Treasury();
     const sender = accounts.get("deployer")!;
@@ -205,7 +205,7 @@ Clarinet.test({
 // ccd002-treasury: get-allowed-asset() succeeds and returns none if asset is not in map
 Clarinet.test({
   name: "ccd002-treasury: get-allowed-asset() succeeds and returns none if asset is not in map",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd002Treasury = new CCD002Treasury();
     const sender = accounts.get("deployer")!;
@@ -230,7 +230,7 @@ Clarinet.test({
 // ccd002-treasury: callback() succeeds when called directly
 Clarinet.test({
   name: "ccd002-treasury: callback() succeeds when called directly",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const ccd002Treasury = new CCD002Treasury();
     const sender = accounts.get("deployer")!;

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -1,19 +1,19 @@
-const address = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+export const ADDRESS = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
 
-export const BASE_DAO = address.concat(".base-dao");
+export const BASE_DAO = ADDRESS.concat(".base-dao");
 
 export const EXTENSIONS = {
-  CCD001_DIRECT_EXECUTE: address.concat(".ccd001-direct-execute"),
-  CCD002_TREASURY: address.concat(".ccd002-treasury"),
-  CCD002_TREASURY_MIA: address.concat(".ccd002-treasury-mia"),
-  CCD002_TREASURY_NYC: address.concat(".ccd002-treasury-nyc"),
+  CCD001_DIRECT_EXECUTE: ADDRESS.concat(".ccd001-direct-execute"),
+  CCD002_TREASURY: ADDRESS.concat(".ccd002-treasury"),
+  CCD002_TREASURY_MIA: ADDRESS.concat(".ccd002-treasury-mia"),
+  CCD002_TREASURY_NYC: ADDRESS.concat(".ccd002-treasury-nyc"),
 };
 
 export const PROPOSALS = {
-  CCIP_012: address.concat(".ccip012-bootstrap"),
+  CCIP_012: ADDRESS.concat(".ccip012-bootstrap"),
 };
 
 export const EXTERNAL = {
-  FT_MIA: address.concat(".miamicoin-token-v2"),
-  FT_NYC: address.concat(".newyorkcitycoin-token-v2"),
+  FT_MIA: ADDRESS.concat(".miamicoin-token-v2"),
+  FT_NYC: ADDRESS.concat(".newyorkcitycoin-token-v2"),
 };

--- a/utils/deps.ts
+++ b/utils/deps.ts
@@ -3,24 +3,13 @@ export type {
   Block,
   ReadOnlyFn,
   TxReceipt,
-} from "https://deno.land/x/clarinet@v0.34.0/index.ts";
+} from "https://deno.land/x/clarinet@v1.0.4/index.ts";
 
 export {
   Clarinet,
   Chain,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.34.0/index.ts";
+} from "https://deno.land/x/clarinet@v1.0.4/index.ts";
 
 export { assertEquals } from "https://deno.land/std@0.113.0/testing/asserts.ts";
-
-export {
-  describe,
-  it,
-  beforeAll,
-  beforeEach,
-  afterAll,
-  afterEach,
-  test,
-  run,
-} from "https://deno.land/x/dspec@v0.2.0/mod.ts";


### PR DESCRIPTION
This PR supersedes #8 and applies the same changes but to the updated codebase rather than fighting merge conflicts in that PR.

Another subtle change - this exports the ADDRESS constant used for all contract tests, and uses that within the tests to limit the amount of hardcoding.

Shout out to @hugocaillard for the original fixes, this just ports them over :sunglasses: 