### PR TITLE
Update city activation details

### DIFF
--- a/contracts/extensions/ccd005-city-data.clar
+++ b/contracts/extensions/ccd005-city-data.clar
@@ -22,7 +22,7 @@
 
 (define-map CityActivationDetails
   uint
-  { activated: uint, delay: uint, target: uint, threshold: uint }
+  { succeeded: uint, delay: uint, activated: uint, threshold: uint }
 )
 
 (define-map CityTreasuryNonce uint uint)
@@ -106,14 +106,14 @@
   )
 )
 
-(define-public (set-city-activation-details (cityId uint) (activated uint) (delay uint) (target uint) (threshold uint))
+(define-public (set-city-activation-details (cityId uint) (succeeded uint) (delay uint) (activated uint) (threshold uint))
   (begin
     (try! (is-dao-or-extension))
     (unwrap! (contract-call? .ccd004-city-registry get-city-name cityId) ERR_INVALID_CITY)
     (ok (map-set CityActivationDetails cityId {
-      activated: activated,
+      succeeded: succeeded,
       delay: delay,
-      target: target,
+      activated: activated,
       threshold: threshold
     }))
   )

--- a/contracts/extensions/ccd008-city-activation.clar
+++ b/contracts/extensions/ccd008-city-activation.clar
@@ -9,7 +9,6 @@
 
 ;; CONSTANTS
 
-;; TODO: update error codes
 (define-constant ERR_UNAUTHORIZED (err u8000))
 (define-constant ERR_ACTIVATION_DETAILS_NOT_FOUND (err u8001))
 (define-constant ERR_CONTRACT_ALREADY_ACTIVE (err u8002))
@@ -57,7 +56,6 @@
         (try! (as-contract
           (contract-call? .ccd005-city-data set-city-activation-details cityId block-height (get delay details) (+ block-height (get delay details)) (get threshold details))
         ))
-        ;; TODO: what else needs to be set here?
       )
     )
     (ok true)

--- a/tests/extensions/ccd005-city-data.test.ts
+++ b/tests/extensions/ccd005-city-data.test.ts
@@ -36,11 +36,11 @@ const nycTreasuryName = "nyc-treasury";
 const nycStackingTreasury = 1;
 const nycMiningTreasury = 2;
 
-const testExpectedCityDetails = (ccd005CityData: any, cityId: number, activated: number, delay: number, target: number, threshold: number) => {
+const testExpectedCityDetails = (ccd005CityData: any, cityId: number, succeeded: number, delay: number, activated: number, threshold: number) => {
   const expectedStats = {
-    activated: types.uint(activated),
+    succeeded: types.uint(succeeded),
     delay: types.uint(delay),
-    target: types.uint(target),
+    activated: types.uint(activated),
     threshold: types.uint(threshold),
   };
   assertEquals(ccd005CityData.getCityActivationDetails(cityId).result.expectSome().expectTuple(), expectedStats);
@@ -147,9 +147,9 @@ Clarinet.test({
     // arrange
     const sender = accounts.get("deployer")!;
     const ccd005CityData = new CCD005CityData(chain, sender, "ccd005-city-data");
-    const activated = 1;
+    const succeeded = 1;
     const delay = 1;
-    const target = 1;
+    const activated = 1;
     const threshold = 1;
 
     // act
@@ -160,7 +160,7 @@ Clarinet.test({
 
     // assert
     ccd005CityData.isCityActivated(miaCityId).result.expectBool(true); //.expectOk().expectSome().expectBool(true);
-    testExpectedCityDetails(ccd005CityData, miaCityId, activated, delay, target, threshold);
+    testExpectedCityDetails(ccd005CityData, miaCityId, succeeded, delay, activated, threshold);
   },
 });
 

--- a/tests/extensions/ccd008-city-activation.test.ts
+++ b/tests/extensions/ccd008-city-activation.test.ts
@@ -10,11 +10,11 @@ import { CCD008CityActivation } from "../../models/extensions/ccd008-city-activa
 const miaCityId = 1;
 const nycCityId = 2;
 
-const testExpectedCityDetails = (ccd005CityData: any, cityId: number, activated: number, delay: number, target: number, threshold: number) => {
+const testExpectedCityDetails = (ccd005CityData: any, cityId: number, succeeded: number, delay: number, activated: number, threshold: number) => {
   const expectedStats = {
-    activated: types.uint(activated),
+    succeeded: types.uint(succeeded),
     delay: types.uint(delay),
-    target: types.uint(target),
+    activated: types.uint(activated),
     threshold: types.uint(threshold),
   };
   assertEquals(ccd005CityData.getCityActivationDetails(cityId).result.expectSome().expectTuple(), expectedStats);


### PR DESCRIPTION
The original language used activated to represent the block that the final user registered, followed by the target block which would be activation + delay.

This was confusing in the tests and when comparing to the original MIA/NYC data passed in by CCIP-013.

Instead we can use succeeded for the block that the final user registered, and activated will represent the succeeded + delay, so that activated means activated in the context of the protocol.