### PR TITLE
Update shellcheck errors and print formatting

### DIFF
--- a/scripts/copy-contracts.sh
+++ b/scripts/copy-contracts.sh
@@ -4,31 +4,41 @@
 
 export SERVICE=$1
 
-infile=contracts/extensions/ccd006-city-mining.clar
-outfile=tests/contracts/extensions/ccd006-city-mining.clar
-m1In="'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.citycoin-vrf-v2"
+printf "Working Directory: %s\n" "$(pwd)"
+
+printf "Updating ccd006-city-mining.clar\n"
+
+infile="contracts/extensions/ccd006-city-mining.clar"
+outfile="tests/contracts/extensions/ccd006-city-mining.clar"
+m1In=("'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.citycoin-vrf-v2")
 m1Out=".citycoin-vrf-v2"
-m2In="'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2"
+m2In=("'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2")
 m2Out=".test-ccext-governance-token-mia"
-m3In="'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-token-v2"
+m3In=("'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-token-v2")
 m3Out=".test-ccext-governance-token-nyc"
 
-printf "Working Directory: `pwd`\n"
-printf "Copying and replacing: $infile to $outfile\n"
+printf "  Source: %s\n" $infile
+printf "  Destination: %s\n" $outfile
 
-sed 's/'$m1In'/'$m1Out'/g;s/'$m2In'/'$m2Out'/g;s/'$m3In'/'$m3Out'/g;' $infile > $outfile
+sed 's/'"${m1In[0]}"'/'$m1Out'/g;s/'"${m2In[0]}"'/'$m2Out'/g;s/'"${m3In[0]}"'/'$m3Out'/g;' $infile > $outfile
 
-infile=contracts/extensions/ccd007-city-stacking.clar
-outfile=tests/contracts/extensions/ccd007-city-stacking.clar
+printf "Updating ccd007-city-stacking.clar\n"
 
-printf "Copying and replacing: $infile to $outfile\n"
+infile="contracts/extensions/ccd007-city-stacking.clar"
+outfile="tests/contracts/extensions/ccd007-city-stacking.clar"
 
-sed 's/'$m2In'/'$m2Out'/g;s/'$m3In'/'$m3Out'/g;' $infile > $outfile
+printf "  Source: %s\n" $infile
+printf "  Destination: %s\n" $outfile
 
-printf "\nCopying Clarinet.local.toml to Clarinet.toml:\n\n"
+sed 's/'"${m2In[0]}"'/'$m2Out'/g;s/'"${m3In[0]}"'/'$m3Out'/g;' $infile > $outfile
+
+printf "Updating Clarinet.toml\n"
+
+printf "  Source: %s\n" Clarinet.local.toml
+printf "  Destination: %s\n" Clarinet.toml
 
 cp Clarinet.local.toml Clarinet.toml
 
-printf "Finished!"
+printf "Finished!\n"
 
 exit 0;


### PR DESCRIPTION
The original script worked fine but shellcheck was complaining about the single quote in the contract principals.

The fix was to use an array instead. It's a bit more complicated, but it makes sense to follow the conventions where possible. Double quotes were added in a few places as well.

The printing was reordered and indentation added to be clearer on smaller screens. Sample output below:

```
Working Directory: /home/whoabuddy/Dev/citycoins/protocol
Updating ccd006-city-mining.clar
  Source: contracts/extensions/ccd006-city-mining.clar
  Destination: tests/contracts/extensions/ccd006-city-mining.clar
Updating ccd007-city-stacking.clar
  Source: contracts/extensions/ccd007-city-stacking.clar
  Destination: tests/contracts/extensions/ccd007-city-stacking.clar
Updating Clarinet.toml
  Source: Clarinet.local.toml
  Destination: Clarinet.toml
Finished!
```

Since this was a bigger change to what you wrote wanted to separate it - if it sounds good to you go ahead and merge into the original PR!