### PR TITLE
Unify contract details

### DIFF
--- a/contracts/extensions/ccd001-direct-execute.clar
+++ b/contracts/extensions/ccd001-direct-execute.clar
@@ -1,6 +1,6 @@
 ;; Title: CCD001 Direct Execute
 ;; Version: 1.0.0
-;; Synopsis: This extension allows a small number of very trusted principals to immediately execute a proposal once a super majority is reached. 
+;; Summary: Allows a small number of very trusted principals to immediately execute a proposal once a super majority is reached. 
 ;; Description: An extension meant for the bootstrapping period of a DAO. It temporarily gives trusted principals the ability to perform a "direct execution"; meaning, they can immediately execute a proposal with the required signals. The Direct Execute extension is set with a sunset period of ~6 months from deployment. Approvers, the parameters, and sunset period may be changed by means of a future proposal.
 
 ;; TRAITS

--- a/contracts/extensions/ccd002-treasury.clar
+++ b/contracts/extensions/ccd002-treasury.clar
@@ -1,6 +1,6 @@
 ;; Title: CCD002 Treasury
 ;; Version: 1.0.0
-;; Synopsis: A treasury contract that can manage STX, SIP-009 NFTs, and SIP-010 FTs.
+;; Summary: A treasury contract that can manage STX, SIP-009 NFTs, and SIP-010 FTs.
 ;; Description: An extension contract that holds assets on behalf of the DAO. SIP-009 and SIP-010 assets must be allowed before they are supported. Deposits can be made by anyone either by transferring to the contract or using a deposit function below. Withdrawals are restricted to the DAO through either extensions or proposals.
 
 ;; TRAITS

--- a/contracts/extensions/ccd003-user-registry.clar
+++ b/contracts/extensions/ccd003-user-registry.clar
@@ -1,6 +1,6 @@
 ;; Title: CCD003 User Registration
 ;; Version: 1.0.0
-;; Synopsis: A central user registry for the CityCoins protocol.
+;; Summary: A central user registry for the CityCoins protocol.
 ;; Description: An extension contract that associates an address (principal) with an ID (uint) for use in other CityCoins extensions.
 
 ;; TRAITS

--- a/contracts/extensions/ccd004-city-registry.clar
+++ b/contracts/extensions/ccd004-city-registry.clar
@@ -1,10 +1,7 @@
 ;; Title: CCD004 City Registration
 ;; Version: 1.0.0
-;; Synopsis:
-;; A central city registry for the CityCoins protocol.
-;; Description:
-;; An extension contract that associates a city name (string-ascii 10)
-;; with an ID (uint) for use in other CityCoins extensions.
+;; Summary: A central city registry for the CityCoins protocol.
+;; Description: An extension contract that associates a city name (string-ascii 10) with an ID (uint) for use in other CityCoins extensions.
 
 ;; TRAITS
 

--- a/contracts/extensions/ccd005-city-data.clar
+++ b/contracts/extensions/ccd005-city-data.clar
@@ -1,6 +1,6 @@
 ;; Title: CCD005 City Data
 ;; Version: 1.0.0
-;; Synopsis: A datastore for city information in the CityCoins protocol.
+;; Summary: A datastore for city information in the CityCoins protocol.
 ;; Description: An extension contract that uses the city ID as the key for storing city information. This contract is used by other CityCoins extensions to store and retrieve city information.
 
 ;; TRAITS

--- a/contracts/extensions/ccd006-city-mining.clar
+++ b/contracts/extensions/ccd006-city-mining.clar
@@ -1,6 +1,6 @@
 ;; Title: CCD006 City Mining
 ;; Version: 1.0.0
-;; Synopsis: A central city mining contract for the CityCoins protocol.
+;; Summary: A central city mining contract for the CityCoins protocol.
 ;; Description: An extension that provides a mining interface per city, in which each mining participant spends STX per block for a weighted chance to mint new CityCoins per the issuance schedule.
 
 ;; TRAITS

--- a/contracts/extensions/ccd007-city-stacking.clar
+++ b/contracts/extensions/ccd007-city-stacking.clar
@@ -1,6 +1,6 @@
 ;; Title: CCD007 City Stacking
 ;; Version: 1.0.0
-;; Synopsis: A central city stacking contract for the CityCoins protocol.
+;; Summary: A central city stacking contract for the CityCoins protocol.
 ;; Description: An extension that provides a stacking interface per city, in which a user can lock their CityCoins for a specified number of cycles, in return for a proportion of the stacking rewards accrued by the related city wallet.
 
 ;; TRAITS

--- a/contracts/extensions/ccd008-city-activation.clar
+++ b/contracts/extensions/ccd008-city-activation.clar
@@ -1,6 +1,6 @@
 ;; Title: CCD008 City Activation
 ;; Version: 1.0.0
-;; Synopsis: This extension allows anyone to vote on activating a city once it's been added to CCD005 City Data.
+;; Summary: This extension allows anyone to vote on activating a city once it's been added to CCD005 City Data.
 ;; Description: An extension contract that handles the voting process for activating a city and setting the related data.
 
 ;; TRAITS

--- a/contracts/extensions/ccd009-auth-v2-adapter.clar
+++ b/contracts/extensions/ccd009-auth-v2-adapter.clar
@@ -1,6 +1,6 @@
 ;; Title: CCD009 Auth V2 Adapter
 ;; Version: 1.0.0
-;; Synopsis: This extension connects to the auth v2 contract in the CityCoins protocol as an approver.
+;; Summary: Connects to the auth v2 contract in the CityCoins protocol as an approver.
 ;; Description: This allows the DAO to access protected contract functions in the old protocol as part of CCIP-010.
 
 ;; TRAITS

--- a/contracts/extensions/ccd009-auth-v2-adapter.clar
+++ b/contracts/extensions/ccd009-auth-v2-adapter.clar
@@ -1,7 +1,7 @@
 ;; Title: CCD009 Auth V2 Adapter
 ;; Version: 1.0.0
-;; Summary: Connects to the auth v2 contract in the CityCoins protocol as an approver.
-;; Description: This allows the DAO to access protected contract functions in the old protocol as part of CCIP-010.
+;; Summary: Connects to the auth v2 contract in the CityCoins legacy protocol as an approver.
+;; Description: An extension contract that allows the DAO to access protected contract functions in the legacy protocol as part of CCIP-010.
 
 ;; TRAITS
 


### PR DESCRIPTION
This PR replaces the word `synopsis` with `summary` at the top of each contract, and makes some small adjustments so that the formatting is consistent across each.

The same summary and description are now on the documentation page for [CityCoin contracts](https://docs.citycoins.co/developer-resources/citycoin-contracts), with additional information about the testnet deployment underway.