### PR TITLE
Use sugared syntax where possible

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -39,5 +39,6 @@ comment:
   require_head: true
 
 ignore:
+  - "contracts/legacy"
   - "tests/contracts/external"
   - "tests/contracts/proposals"

--- a/.github/workflows/test-contracts.yaml
+++ b/.github/workflows/test-contracts.yaml
@@ -25,11 +25,11 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v3
       - name: "Check contract syntax"
-        uses: docker://hirosystems/clarinet@1.4.2
+        uses: docker://hirosystems/clarinet:1.4.2
         with:
           args: check
       - name: "Run all contract tests"
-        uses: docker://hirosystems/clarinet@1.4.2
+        uses: docker://hirosystems/clarinet:1.4.2
         with:
           args: test --coverage
       - name: "Upload code coverage"

--- a/.github/workflows/test-contracts.yaml
+++ b/.github/workflows/test-contracts.yaml
@@ -25,11 +25,11 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v3
       - name: "Check contract syntax"
-        uses: docker://hirosystems/clarinet:latest
+        uses: docker://hirosystems/clarinet@1.4.2
         with:
           args: check
       - name: "Run all contract tests"
-        uses: docker://hirosystems/clarinet:latest
+        uses: docker://hirosystems/clarinet@1.4.2
         with:
           args: test --coverage
       - name: "Upload code coverage"

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -335,6 +335,9 @@ path = "tests/contracts/proposals/test-ccd007-citycoin-stacking-010.clar"
 [contracts.test-ccd007-citycoin-stacking-011]
 path = "tests/contracts/proposals/test-ccd007-citycoin-stacking-011.clar"
 
+[contracts.test-ccd007-citycoin-stacking-012]
+path = "tests/contracts/proposals/test-ccd007-citycoin-stacking-012.clar"
+
 [contracts.test-ccd011-stacking-payouts-001]
 path = "tests/contracts/proposals/test-ccd011-stacking-payouts-001.clar"
 

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -171,6 +171,32 @@ path = "tests/contracts/external/test-ccext-nft-mia.clar"
 [contracts.test-ccext-nft-nyc]
 path = "tests/contracts/external/test-ccext-nft-nyc.clar"
 
+# CITYCOINS LEGACY CONTRACTS
+
+[contracts.citycoin-core-v2-trait]
+path = "contracts/legacy/citycoin-core-v2-trait.clar"
+
+[contracts.citycoin-token-v2-trait]
+path = "contracts/legacy/citycoin-token-v2-trait.clar"
+
+[contracts.miamicoin-auth-v2]
+path = "contracts/legacy/miamicoin-auth-v2.clar"
+
+[contracts.miamicoin-core-v2]
+path = "contracts/legacy/miamicoin-core-v2.clar"
+
+[contracts.miamicoin-token-v2]
+path = "contracts/legacy/miamicoin-token-v2.clar"
+
+[contracts.newyorkcitycoin-auth-v2]
+path = "contracts/legacy/newyorkcitycoin-auth-v2.clar"
+
+[contracts.newyorkcitycoin-core-v2]
+path = "contracts/legacy/newyorkcitycoin-core-v2.clar"
+
+[contracts.newyorkcitycoin-token-v2]
+path = "contracts/legacy/newyorkcitycoin-token-v2.clar"
+
 # CITYCOINS TEST PROPOSALS
 
 [contracts.test-ccd001-direct-execute-001]

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -302,6 +302,9 @@ path = "tests/contracts/proposals/test-ccd006-citycoin-mining-003.clar"
 [contracts.test-ccd006-citycoin-mining-004]
 path = "tests/contracts/proposals/test-ccd006-citycoin-mining-004.clar"
 
+[contracts.test-ccd006-citycoin-mining-005]
+path = "tests/contracts/proposals/test-ccd006-citycoin-mining-005.clar"
+
 [contracts.test-ccd007-citycoin-stacking-001]
 path = "tests/contracts/proposals/test-ccd007-citycoin-stacking-001.clar"
 

--- a/contracts/extensions/ccd001-direct-execute.clar
+++ b/contracts/extensions/ccd001-direct-execute.clar
@@ -65,6 +65,7 @@
 (define-public (set-signals-required (signals uint))
   (begin
     (try! (is-dao-or-extension))
+    (asserts! (> signals u0) ERR_UNAUTHORIZED)
     (print {
       event: "set-signals-required",
       signals: signals

--- a/contracts/extensions/ccd003-user-registry.clar
+++ b/contracts/extensions/ccd003-user-registry.clar
@@ -1,4 +1,4 @@
-;; Title: CCD003 User Registration
+;; Title: CCD003 User Registry
 ;; Version: 1.0.0
 ;; Summary: A central user registry for the CityCoins protocol.
 ;; Description: An extension contract that associates an address (principal) with an ID (uint) for use in other CityCoins extensions.

--- a/contracts/extensions/ccd004-city-registry.clar
+++ b/contracts/extensions/ccd004-city-registry.clar
@@ -1,4 +1,4 @@
-;; Title: CCD004 City Registration
+;; Title: CCD004 City Registry
 ;; Version: 1.0.0
 ;; Summary: A central city registry for the CityCoins protocol.
 ;; Description: An extension contract that associates a city name (string-ascii 10) with an ID (uint) for use in other CityCoins extensions.

--- a/contracts/extensions/ccd006-citycoin-mining.clar
+++ b/contracts/extensions/ccd006-citycoin-mining.clar
@@ -70,16 +70,20 @@
 (define-public (set-reward-delay (delay uint))
   (begin 
     (try! (is-dao-or-extension))
+    (print {
+      event: "set-reward-delay",
+      rewardDelay: delay
+    })
     (asserts! (> delay u0) ERR_INVALID_DELAY)
     (ok (var-set rewardDelay delay))
   )
 )
 
-(define-public (set-mining-status (status bool))
+(define-public (set-mining-enabled (status bool))
   (begin
     (try! (is-dao-or-extension))
     (print {
-      event: "set-mining-status",
+      event: "set-mining-enabled",
       miningEnabled: status
     })
     (ok (var-set miningEnabled status))

--- a/contracts/extensions/ccd006-citycoin-mining.clar
+++ b/contracts/extensions/ccd006-citycoin-mining.clar
@@ -1,4 +1,4 @@
-;; Title: CCD006 City Mining
+;; Title: CCD006 CityCoin Mining
 ;; Version: 1.0.0
 ;; Summary: A central city mining contract for the CityCoins protocol.
 ;; Description: An extension that provides a mining interface per city, in which each mining participant spends STX per block for a weighted chance to mint new CityCoins per the issuance schedule.

--- a/contracts/extensions/ccd006-citycoin-mining.clar
+++ b/contracts/extensions/ccd006-citycoin-mining.clar
@@ -182,7 +182,7 @@
 )
 
 (define-read-only (get-miner (cityId uint) (height uint) (userId uint))
-  (default-to { commit: u0, low: u0, high: u0 }
+  (default-to { commit: u0, low: u0, high: u0, winner: false }
     (map-get? Miners { cityId: cityId, height: height, userId: userId })
   )
 )

--- a/contracts/extensions/ccd007-citycoin-stacking.clar
+++ b/contracts/extensions/ccd007-citycoin-stacking.clar
@@ -128,12 +128,10 @@
 
 (define-public (set-stacking-reward (cityId uint) (cycleId uint) (amount uint))
   (let
-    (
-      (cycleStats (get-stacking-stats cityId cycleId))
-    )
+    ((cycleStats (get-stacking-stats cityId cycleId)))
     (try! (is-extension))
     (asserts! (is-none (get reward cycleStats)) ERR_PAYOUT_COMPLETE)
-    (asserts! (< cycleId (get-reward-cycle burn-block-height)) ERR_INCOMPLETE_CYCLE)
+    (asserts! (or (not (var-get stackingEnabled)) (< cycleId (get-reward-cycle burn-block-height))) ERR_INCOMPLETE_CYCLE)
     (ok (map-set StackingStats
       { cityId: cityId, cycle: cycleId }
       (merge cycleStats { reward: (some amount) })
@@ -186,11 +184,11 @@
   )
 )
 
-(define-public (set-stacking-status (status bool))
+(define-public (set-stacking-enabled (status bool))
   (begin
     (try! (is-dao-or-extension))
     (print {
-      event: "set-stacking-status",
+      event: "set-stacking-enabled",
       stackingEnabled: status
     })
     (ok (var-set stackingEnabled status))
@@ -232,7 +230,7 @@
 )
 
 (define-read-only (is-cycle-paid (cityId uint) (cycle uint))
-    (is-some (get reward (get-stacking-stats cityId cycle)))
+  (is-some (get reward (get-stacking-stats cityId cycle)))
 )
 
 (define-read-only (get-stacking-reward (cityId uint) (userId uint) (cycle uint))

--- a/contracts/extensions/ccd007-citycoin-stacking.clar
+++ b/contracts/extensions/ccd007-citycoin-stacking.clar
@@ -1,4 +1,4 @@
-;; Title: CCD007 City Stacking
+;; Title: CCD007 CityCoin Stacking
 ;; Version: 1.0.0
 ;; Summary: A central city stacking contract for the CityCoins protocol.
 ;; Description: An extension that provides a stacking interface per city, in which a user can lock their CityCoins for a specified number of cycles, in return for a proportion of the stacking rewards accrued by the related city wallet.

--- a/contracts/extensions/ccd007-citycoin-stacking.clar
+++ b/contracts/extensions/ccd007-citycoin-stacking.clar
@@ -249,7 +249,7 @@
   )
 )
 
-(define-read-only (get-stacking-status)
+(define-read-only (is-stacking-enabled)
   (var-get stackingEnabled)
 )
 

--- a/contracts/extensions/ccd007-citycoin-stacking.clar
+++ b/contracts/extensions/ccd007-citycoin-stacking.clar
@@ -242,7 +242,7 @@
     )
     (if (and (not (var-get claimsEnabled)) (or (<= (get-reward-cycle burn-block-height) cycle) (is-eq userStacked u0)))
       none
-      (some (/ (* (unwrap! (get reward cycleStats) none) userStacked) (get total cycleStats)))
+      (some (/ (* (unwrap! (get reward cycleStats) (some u0)) userStacked) (get total cycleStats)))
     )
   )
 )

--- a/contracts/extensions/ccd010-core-v2-adapter.clar
+++ b/contracts/extensions/ccd010-core-v2-adapter.clar
@@ -1,7 +1,7 @@
 ;; Title: CCD010 Core V2 Adapter
 ;; Version: 1.0.0
-;; Summary: Simulates a core v2 contract in the CityCoins legacy protocol to mint CityCoins won by miners.
-;; Description: An extension contract that allows the DAO to mint tokens in the legacy protocol.
+;; Summary: Simulates a core v2 contract in the CityCoins legacy protocol.
+;; Description: An extension contract that allows the DAO to process and mint CityCoins from the legacy protocol won by miners.
 
 ;; TRAITS
 

--- a/contracts/legacy/citycoin-core-v2-trait.clar
+++ b/contracts/legacy/citycoin-core-v2-trait.clar
@@ -1,0 +1,47 @@
+;; CITYCOIN CORE TRAIT V2
+
+(define-trait citycoin-core-v2
+  (
+
+    (register-user ((optional (string-utf8 50)))
+      (response bool uint)
+    )
+
+    (mine-tokens (uint (optional (buff 34)))
+      (response bool uint)
+    )
+
+    (mine-many ((list 200 uint))
+      (response bool uint)
+    )
+
+    (claim-mining-reward (uint)
+      (response bool uint)
+    )
+
+    (stack-tokens (uint uint)
+      (response bool uint)
+    )
+
+    (claim-stacking-reward (uint)
+      (response bool uint)
+    )
+
+    (set-city-wallet (principal)
+      (response bool uint)
+    )
+
+    (update-coinbase-amounts ()
+      (response bool uint)
+    )
+
+    (update-coinbase-thresholds ()
+      (response bool uint)
+    )
+    
+    (shutdown-contract (uint)
+      (response bool uint)
+    )
+
+  )
+)

--- a/contracts/legacy/citycoin-token-v2-trait.clar
+++ b/contracts/legacy/citycoin-token-v2-trait.clar
@@ -1,0 +1,35 @@
+;; CITYCOIN TOKEN TRAIT
+
+(define-trait citycoin-token-v2
+  (
+
+    (activate-token (principal uint)
+      (response bool uint)
+    )
+
+    (set-token-uri ((optional (string-utf8 256)))
+      (response bool uint)
+    )
+
+    (mint (uint principal)
+      (response bool uint)
+    )
+
+    (burn (uint principal)
+      (response bool uint)
+    )
+
+    (send-many ((list 200 { to: principal, amount: uint, memo: (optional (buff 34)) }))
+      (response bool uint)
+    )
+
+    (update-coinbase-thresholds (uint uint uint uint uint)
+      (response bool uint)
+    )
+
+    (update-coinbase-amounts (uint uint uint uint uint uint uint)
+      (response bool uint)
+    )
+
+  )
+)

--- a/contracts/legacy/miamicoin-auth-v2.clar
+++ b/contracts/legacy/miamicoin-auth-v2.clar
@@ -1,0 +1,630 @@
+;; MIAMICOIN AUTH CONTRACT V2 TESTNET
+;; CityCoins Protocol Version 2.0.0
+
+(define-constant CONTRACT_OWNER tx-sender)
+
+;; TRAIT DEFINITIONS
+
+(use-trait coreTraitV2 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-core-v2-trait.citycoin-core-v2)
+(use-trait tokenTraitV2 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-token-v2-trait.citycoin-token-v2)
+
+;; ERRORS
+
+(define-constant ERR_UNKNOWN_JOB (err u6000))
+(define-constant ERR_UNAUTHORIZED (err u6001))
+(define-constant ERR_JOB_IS_ACTIVE (err u6002))
+(define-constant ERR_JOB_IS_NOT_ACTIVE (err u6003))
+(define-constant ERR_ALREADY_VOTED_THIS_WAY (err u6004))
+(define-constant ERR_JOB_IS_EXECUTED (err u6005))
+(define-constant ERR_JOB_IS_NOT_APPROVED (err u6006))
+(define-constant ERR_ARGUMENT_ALREADY_EXISTS (err u6007))
+(define-constant ERR_NO_ACTIVE_CORE_CONTRACT (err u6008))
+(define-constant ERR_CORE_CONTRACT_NOT_FOUND (err u6009))
+(define-constant ERR_UNKNOWN_ARGUMENT (err u6010))
+(define-constant ERR_INCORRECT_CONTRACT_STATE (err u6011))
+(define-constant ERR_CONTRACT_ALREADY_EXISTS (err u6012))
+
+;; JOB MANAGEMENT
+
+(define-constant REQUIRED_APPROVALS u2) ;; TESTNET: set to 2 approvals
+
+(define-data-var lastJobId uint u0)
+
+(define-map Jobs
+  uint
+  {
+    creator: principal,
+    name: (string-ascii 255),
+    target: principal,
+    approvals: uint,
+    disapprovals: uint,
+    isActive: bool,
+    isExecuted: bool
+  }
+)
+
+(define-map JobApprovers
+  { jobId: uint, approver: principal }
+  bool
+)
+
+(define-map Approvers
+  principal
+  bool
+)
+
+(define-map ArgumentLastIdsByType
+  { jobId: uint, argumentType: (string-ascii 25) }
+  uint
+)
+
+(define-map UIntArgumentsByName
+  { jobId: uint, argumentName: (string-ascii 255) }
+  { argumentId: uint, value: uint}
+)
+
+(define-map UIntArgumentsById
+  { jobId: uint, argumentId: uint }
+  { argumentName: (string-ascii 255), value: uint }
+)
+
+(define-map PrincipalArgumentsByName
+  { jobId: uint, argumentName: (string-ascii 255) }
+  { argumentId: uint, value: principal }
+)
+
+(define-map PrincipalArgumentsById
+  { jobId: uint, argumentId: uint }
+  { argumentName: (string-ascii 255), value: principal }
+)
+
+;; FUNCTIONS
+
+(define-read-only (get-last-job-id)
+  (var-get lastJobId)
+)
+
+(define-public (create-job (name (string-ascii 255)) (target principal))
+  (let
+    (
+      (newJobId (+ (var-get lastJobId) u1))
+    )
+    (asserts! (is-approver tx-sender) ERR_UNAUTHORIZED)
+    (map-set Jobs
+      newJobId
+      {
+        creator: tx-sender,
+        name: name,
+        target: target,
+        approvals: u0,
+        disapprovals: u0,
+        isActive: false,
+        isExecuted: false
+      }
+    )
+    (var-set lastJobId newJobId)
+    (ok newJobId)
+  )
+)
+
+(define-read-only (get-job (jobId uint))
+  (map-get? Jobs jobId)
+)
+
+(define-public (activate-job (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+    )
+    (asserts! (is-eq (get creator job) tx-sender) ERR_UNAUTHORIZED)
+    (asserts! (not (get isActive job)) ERR_JOB_IS_ACTIVE)
+    (map-set Jobs 
+      jobId
+      (merge job { isActive: true })
+    )
+    (ok true)
+  )
+)
+
+(define-public (approve-job (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+      (previousVote (map-get? JobApprovers { jobId: jobId, approver: tx-sender }))
+    )
+    (asserts! (get isActive job) ERR_JOB_IS_NOT_ACTIVE)
+    (asserts! (is-approver tx-sender) ERR_UNAUTHORIZED)
+    ;; save vote
+    (map-set JobApprovers
+      { jobId: jobId, approver: tx-sender }
+      true
+    )
+    (match previousVote approved
+      (begin
+        (asserts! (not approved) ERR_ALREADY_VOTED_THIS_WAY)
+        (map-set Jobs jobId
+          (merge job 
+            {
+              approvals: (+ (get approvals job) u1),
+              disapprovals: (- (get disapprovals job) u1)
+            }
+          )
+        )
+      )
+      ;; no previous vote
+      (map-set Jobs
+        jobId
+        (merge job { approvals: (+ (get approvals job) u1) } )
+      )
+    )  
+    (ok true)
+  )
+)
+
+(define-public (disapprove-job (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+      (previousVote (map-get? JobApprovers { jobId: jobId, approver: tx-sender }))
+    )
+    (asserts! (get isActive job) ERR_JOB_IS_NOT_ACTIVE)
+    (asserts! (is-approver tx-sender) ERR_UNAUTHORIZED)
+    ;; save vote
+    (map-set JobApprovers
+      { jobId: jobId, approver: tx-sender }
+      false
+    )
+    (match previousVote approved
+      (begin
+        (asserts! approved ERR_ALREADY_VOTED_THIS_WAY)
+        (map-set Jobs jobId
+          (merge job 
+            {
+              approvals: (- (get approvals job) u1),
+              disapprovals: (+ (get disapprovals job) u1)
+            }
+          )
+        )
+      )
+      ;; no previous vote
+      (map-set Jobs
+        jobId
+        (merge job { disapprovals: (+ (get disapprovals job) u1) } )
+      )
+    )
+    (ok true)
+  )
+)
+
+(define-read-only (is-job-approved (jobId uint))
+  (match (get-job jobId) job
+    (>= (get approvals job) REQUIRED_APPROVALS)
+    false
+  )
+)
+
+(define-public (mark-job-as-executed (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+    )
+    (asserts! (get isActive job) ERR_JOB_IS_NOT_ACTIVE)
+    (asserts! (>= (get approvals job) REQUIRED_APPROVALS) ERR_JOB_IS_NOT_APPROVED)
+    (asserts! (is-eq (get target job) contract-caller) ERR_UNAUTHORIZED)
+    (asserts! (not (get isExecuted job)) ERR_JOB_IS_EXECUTED)
+    (map-set Jobs
+      jobId
+      (merge job { isExecuted: true })
+    )
+    (ok true)
+  )
+)
+
+(define-public (add-uint-argument (jobId uint) (argumentName (string-ascii 255)) (value uint))
+  (let
+    (
+      (argumentId (generate-argument-id jobId "uint"))
+    )
+    (try! (guard-add-argument jobId))
+    (asserts! 
+      (and
+        (map-insert UIntArgumentsById
+          { jobId: jobId, argumentId: argumentId }
+          { argumentName: argumentName, value: value }
+        )
+        (map-insert UIntArgumentsByName
+          { jobId: jobId, argumentName: argumentName }
+          { argumentId: argumentId, value: value}
+        )
+      ) 
+      ERR_ARGUMENT_ALREADY_EXISTS
+    )
+    (ok true)
+  )
+)
+
+(define-read-only (get-uint-argument-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (map-get? UIntArgumentsByName { jobId: jobId, argumentName: argumentName })
+)
+
+(define-read-only (get-uint-argument-by-id (jobId uint) (argumentId uint))
+  (map-get? UIntArgumentsById { jobId: jobId, argumentId: argumentId })
+)
+
+(define-read-only (get-uint-value-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (get value (get-uint-argument-by-name jobId argumentName))
+)
+
+(define-read-only (get-uint-value-by-id (jobId uint) (argumentId uint))
+  (get value (get-uint-argument-by-id jobId argumentId))
+)
+
+(define-public (add-principal-argument (jobId uint) (argumentName (string-ascii 255)) (value principal))
+  (let
+    (
+      (argumentId (generate-argument-id jobId "principal"))
+    )
+    (try! (guard-add-argument jobId))
+    (asserts! 
+      (and
+        (map-insert PrincipalArgumentsById
+          { jobId: jobId, argumentId: argumentId }
+          { argumentName: argumentName, value: value }
+        )
+        (map-insert PrincipalArgumentsByName
+          { jobId: jobId, argumentName: argumentName }
+          { argumentId: argumentId, value: value}
+        )
+      ) 
+      ERR_ARGUMENT_ALREADY_EXISTS
+    )
+    (ok true)
+  )
+)
+
+(define-read-only (get-principal-argument-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (map-get? PrincipalArgumentsByName { jobId: jobId, argumentName: argumentName })
+)
+
+(define-read-only (get-principal-argument-by-id (jobId uint) (argumentId uint))
+  (map-get? PrincipalArgumentsById { jobId: jobId, argumentId: argumentId })
+)
+
+(define-read-only (get-principal-value-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (get value (get-principal-argument-by-name jobId argumentName))
+)
+
+(define-read-only (get-principal-value-by-id (jobId uint) (argumentId uint))
+  (get value (get-principal-argument-by-id jobId argumentId))
+)
+
+;; PRIVATE FUNCTIONS
+
+(define-read-only  (is-approver (user principal))
+  (default-to false (map-get? Approvers user))
+)
+
+(define-private (generate-argument-id (jobId uint) (argumentType (string-ascii 25)))
+  (let
+    (
+      (argumentId (+ (default-to u0 (map-get? ArgumentLastIdsByType { jobId: jobId, argumentType: argumentType })) u1))
+    )
+    (map-set ArgumentLastIdsByType
+      { jobId: jobId, argumentType: argumentType }
+      argumentId
+    )
+    ;; return
+    argumentId
+  )
+)
+
+(define-private (guard-add-argument (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+    )
+    (asserts! (not (get isActive job)) ERR_JOB_IS_ACTIVE)
+    (asserts! (is-eq (get creator job) contract-caller) ERR_UNAUTHORIZED)
+    (ok true)
+  )
+)
+
+;; CONTRACT MANAGEMENT
+
+;; initial value for active core contract
+;; set to deployer address at startup to prevent
+;; circular dependency of core on auth
+(define-data-var activeCoreContract principal CONTRACT_OWNER)
+(define-data-var initialized bool false)
+
+;; core contract states
+(define-constant STATE_DEPLOYED u0)
+(define-constant STATE_ACTIVE u1)
+(define-constant STATE_INACTIVE u2)
+
+;; core contract map
+(define-map CoreContracts
+  principal
+  {
+    state: uint, 
+    startHeight: uint,
+    endHeight: uint
+  }
+)
+
+;; getter for active core contract
+(define-read-only (get-active-core-contract)
+  (begin
+    (asserts! (not (is-eq (var-get activeCoreContract) CONTRACT_OWNER)) ERR_NO_ACTIVE_CORE_CONTRACT)
+    (ok (var-get activeCoreContract))
+  )
+)
+
+;; getter for core contract map
+(define-read-only (get-core-contract-info (targetContract principal))
+  (let
+    (
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) ERR_CORE_CONTRACT_NOT_FOUND))
+    )
+    (ok coreContract)
+  )
+)
+
+;; one-time function to initialize contracts after all contracts are deployed
+;; - check that deployer is calling this function
+;; - check this contract is not activated already (one-time use)
+;; - set initial map value for core contract v1
+;; - set cityWallet in core contract
+;; - set intialized true
+(define-public (initialize-contracts (coreContract <coreTraitV2>))
+  (let
+    (
+      (coreContractAddress (contract-of coreContract))
+    )
+    (asserts! (is-eq contract-caller CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (not (var-get initialized)) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      coreContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (try! (contract-call? coreContract set-city-wallet (var-get cityWallet)))
+    (var-set initialized true)
+    (ok true)
+  )
+)
+
+(define-read-only (is-initialized)
+  (var-get initialized)
+)
+
+;; function to activate core contract through registration
+;; - check that target is in core contract map
+;; - check that caller is core contract
+;; - check that target is in STATE_DEPLOYED
+;; - set active in core contract map
+;; - set as activeCoreContract
+(define-public (activate-core-contract (targetContract principal) (stacksHeight uint))
+  (let
+    (
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) ERR_CORE_CONTRACT_NOT_FOUND))
+    )
+    (asserts! (is-eq (get state coreContract) STATE_DEPLOYED) ERR_INCORRECT_CONTRACT_STATE)
+    (asserts! (is-eq contract-caller targetContract) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      targetContract
+      {
+        state: STATE_ACTIVE,
+        startHeight: stacksHeight,
+        endHeight: u0
+      })
+    (var-set activeCoreContract targetContract)
+    (ok true)
+  )
+)
+
+;; protected function to update core contract
+(define-public (upgrade-core-contract (oldContract <coreTraitV2>) (newContract <coreTraitV2>))
+  (let
+    (
+      (oldContractAddress (contract-of oldContract))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+      (newContractAddress (contract-of newContract))
+    )
+    (asserts! (not (is-eq oldContractAddress newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (is-none (map-get? CoreContracts newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      oldContractAddress
+      {
+        state: STATE_INACTIVE,
+        startHeight: (get startHeight oldContractMap),
+        endHeight: block-height
+      })
+    (map-set CoreContracts
+      newContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (var-set activeCoreContract newContractAddress)
+    (try! (contract-call? oldContract shutdown-contract block-height))
+    (try! (contract-call? newContract set-city-wallet (var-get cityWallet)))
+    (ok true)
+  )
+)
+
+(define-public (execute-upgrade-core-contract-job (jobId uint) (oldContract <coreTraitV2>) (newContract <coreTraitV2>))
+  (let
+    (
+      (oldContractArg (unwrap! (get-principal-value-by-name jobId "oldContract") ERR_UNKNOWN_ARGUMENT))
+      (newContractArg (unwrap! (get-principal-value-by-name jobId "newContract") ERR_UNKNOWN_ARGUMENT))
+      (oldContractAddress (contract-of oldContract))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+      (newContractAddress (contract-of newContract))
+    )
+    (asserts! (not (is-eq oldContractAddress newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (is-none (map-get? CoreContracts newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (and (is-eq oldContractArg oldContractAddress) (is-eq newContractArg newContractAddress)) ERR_UNAUTHORIZED)
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      oldContractAddress
+      {
+        state: STATE_INACTIVE,
+        startHeight: (get startHeight oldContractMap),
+        endHeight: block-height
+      })
+    (map-set CoreContracts
+      newContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (var-set activeCoreContract newContractAddress)
+    (try! (contract-call? oldContract shutdown-contract block-height))
+    (try! (contract-call? newContract set-city-wallet (var-get cityWallet)))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; CITY WALLET MANAGEMENT
+
+;; initial value for city wallet
+(define-data-var cityWallet principal 'ST3PM583Q21NF0GB428P79VFPYH8X5DQVKDDGD74T)
+
+;; returns city wallet principal
+(define-read-only (get-city-wallet)
+  (ok (var-get cityWallet))
+)
+ 
+;; protected function to update city wallet variable
+(define-public (set-city-wallet (targetContract <coreTraitV2>) (newCityWallet principal))
+  (let
+    (
+      (coreContractAddress (contract-of targetContract))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+    )
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    (asserts! (is-eq coreContractAddress (var-get activeCoreContract)) ERR_UNAUTHORIZED)
+    (var-set cityWallet newCityWallet)
+    (try! (contract-call? targetContract set-city-wallet newCityWallet))
+    (ok true)
+  )
+)
+
+(define-public (execute-set-city-wallet-job (jobId uint) (targetContract <coreTraitV2>))
+  (let
+    (
+      (coreContractAddress (contract-of targetContract))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+      (newCityWallet (unwrap! (get-principal-value-by-name jobId "newCityWallet") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (asserts! (is-eq coreContractAddress (var-get activeCoreContract)) ERR_UNAUTHORIZED)
+    (var-set cityWallet newCityWallet)
+    (try! (contract-call? targetContract set-city-wallet newCityWallet))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; check if contract caller is city wallet
+(define-private (is-authorized-city)
+  (is-eq contract-caller (var-get cityWallet))
+)
+
+;; TOKEN MANAGEMENT
+
+(define-public (set-token-uri (targetContract <tokenTraitV2>) (newUri (optional (string-utf8 256))))
+  (begin
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    (as-contract (try! (contract-call? targetContract set-token-uri newUri)))
+    (ok true)
+  )
+)
+
+;; COINBASE THRESHOLDS
+
+(define-public (update-coinbase-thresholds (targetCore <coreTraitV2>) (targetToken <tokenTraitV2>) (threshold1 uint) (threshold2 uint) (threshold3 uint) (threshold4 uint) (threshold5 uint))
+  (begin
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    ;; update in token contract
+    (as-contract (try! (contract-call? targetToken update-coinbase-thresholds threshold1 threshold2 threshold3 threshold4 threshold5)))
+    ;; update core contract based on token contract
+    (as-contract (try! (contract-call? targetCore update-coinbase-thresholds)))
+    (ok true)
+  )
+)
+
+(define-public (execute-update-coinbase-thresholds-job (jobId uint) (targetCore <coreTraitV2>) (targetToken <tokenTraitV2>))
+  (let
+    (
+      (threshold1 (unwrap! (get-uint-value-by-name jobId "threshold1") ERR_UNKNOWN_ARGUMENT))
+      (threshold2 (unwrap! (get-uint-value-by-name jobId "threshold2") ERR_UNKNOWN_ARGUMENT))
+      (threshold3 (unwrap! (get-uint-value-by-name jobId "threshold3") ERR_UNKNOWN_ARGUMENT))
+      (threshold4 (unwrap! (get-uint-value-by-name jobId "threshold4") ERR_UNKNOWN_ARGUMENT))
+      (threshold5 (unwrap! (get-uint-value-by-name jobId "threshold5") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (as-contract (try! (contract-call? targetToken update-coinbase-thresholds threshold1 threshold2 threshold3 threshold4 threshold5)))
+    (as-contract (try! (contract-call? targetCore update-coinbase-thresholds)))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; COINBASE AMOUNTS (REWARDS)
+
+(define-public (update-coinbase-amounts (targetCore <coreTraitV2>) (targetToken <tokenTraitV2>) (amountBonus uint) (amount1 uint) (amount2 uint) (amount3 uint) (amount4 uint) (amount5 uint) (amountDefault uint))
+  (begin
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    ;; update in token contract
+    (as-contract (try! (contract-call? targetToken update-coinbase-amounts amountBonus amount1 amount2 amount3 amount4 amount5 amountDefault)))
+    ;; update core contract based on token contract
+    (as-contract (try! (contract-call? targetCore update-coinbase-amounts)))
+    (ok true)
+  )
+)
+
+(define-public (execute-update-coinbase-amounts-job (jobId uint) (targetCore <coreTraitV2>) (targetToken <tokenTraitV2>))
+  (let
+    (
+      (amountBonus (unwrap! (get-uint-value-by-name jobId "amountBonus") ERR_UNKNOWN_ARGUMENT))
+      (amount1 (unwrap! (get-uint-value-by-name jobId "amount1") ERR_UNKNOWN_ARGUMENT))
+      (amount2 (unwrap! (get-uint-value-by-name jobId "amount2") ERR_UNKNOWN_ARGUMENT))
+      (amount3 (unwrap! (get-uint-value-by-name jobId "amount3") ERR_UNKNOWN_ARGUMENT))
+      (amount4 (unwrap! (get-uint-value-by-name jobId "amount4") ERR_UNKNOWN_ARGUMENT))
+      (amount5 (unwrap! (get-uint-value-by-name jobId "amount5") ERR_UNKNOWN_ARGUMENT))
+      (amountDefault (unwrap! (get-uint-value-by-name jobId "amountDefault") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (as-contract (try! (contract-call? targetToken update-coinbase-amounts amountBonus amount1 amount2 amount3 amount4 amount5 amountDefault)))
+    (as-contract (try! (contract-call? targetCore update-coinbase-amounts)))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; APPROVERS MANAGEMENT
+
+(define-public (execute-replace-approver-job (jobId uint))
+  (let
+    (
+      (oldApprover (unwrap! (get-principal-value-by-name jobId "oldApprover") ERR_UNKNOWN_ARGUMENT))
+      (newApprover (unwrap! (get-principal-value-by-name jobId "newApprover") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (map-set Approvers oldApprover false)
+    (map-set Approvers newApprover true)
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; CONTRACT INITIALIZATION
+
+(map-insert Approvers 'ST3AY0CM7SD9183QZ4Y7S2RGBZX9GQT54MJ6XY0BN true)
+(map-insert Approvers 'ST2D06VFWWTNCWHVB2FJ9KJ3EB30HFRTHB1A4BSP3 true)
+(map-insert Approvers 'ST113N3MMPZRMJJRZH6JTHA5CB7TBZH1EH4C22GFV true)
+(map-insert Approvers 'ST8YRW1THF2XT8E45XXCGYKZH2B70HYH71VC7737 true)
+(map-insert Approvers 'STX13Q7ZJDSFVDZMQ1PWDFGT4QSBMASRMCYE4NAP true)

--- a/contracts/legacy/miamicoin-auth-v2.clar
+++ b/contracts/legacy/miamicoin-auth-v2.clar
@@ -5,8 +5,8 @@
 
 ;; TRAIT DEFINITIONS
 
-(use-trait coreTraitV2 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-core-v2-trait.citycoin-core-v2)
-(use-trait tokenTraitV2 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-token-v2-trait.citycoin-token-v2)
+(use-trait coreTraitV2 .citycoin-core-v2-trait.citycoin-core-v2)
+(use-trait tokenTraitV2 .citycoin-token-v2-trait.citycoin-token-v2)
 
 ;; ERRORS
 

--- a/contracts/legacy/miamicoin-core-v2.clar
+++ b/contracts/legacy/miamicoin-core-v2.clar
@@ -1,0 +1,1007 @@
+;; MIAMICOIN CORE CONTRACT V2 TESTNET
+;; CityCoins Protocol Version 2.0.0
+
+;; GENERAL CONFIGURATION
+
+(impl-trait 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-core-v2-trait.citycoin-core-v2)
+(define-constant CONTRACT_OWNER tx-sender)
+
+;; ERROR CODES
+
+(define-constant ERR_UNAUTHORIZED (err u1000))
+(define-constant ERR_USER_ALREADY_REGISTERED (err u1001))
+(define-constant ERR_USER_NOT_FOUND (err u1002))
+(define-constant ERR_USER_ID_NOT_FOUND (err u1003))
+(define-constant ERR_ACTIVATION_THRESHOLD_REACHED (err u1004))
+(define-constant ERR_CONTRACT_NOT_ACTIVATED (err u1005))
+(define-constant ERR_USER_ALREADY_MINED (err u1006))
+(define-constant ERR_INSUFFICIENT_COMMITMENT (err u1007))
+(define-constant ERR_INSUFFICIENT_BALANCE (err u1008))
+(define-constant ERR_USER_DID_NOT_MINE_IN_BLOCK (err u1009))
+(define-constant ERR_CLAIMED_BEFORE_MATURITY (err u1010))
+(define-constant ERR_NO_MINERS_AT_BLOCK (err u1011))
+(define-constant ERR_REWARD_ALREADY_CLAIMED (err u1012))
+(define-constant ERR_MINER_DID_NOT_WIN (err u1013))
+(define-constant ERR_NO_VRF_SEED_FOUND (err u1014))
+(define-constant ERR_STACKING_NOT_AVAILABLE (err u1015))
+(define-constant ERR_CANNOT_STACK (err u1016))
+(define-constant ERR_REWARD_CYCLE_NOT_COMPLETED (err u1017))
+(define-constant ERR_NOTHING_TO_REDEEM (err u1018))
+(define-constant ERR_UNABLE_TO_FIND_CITY_WALLET (err u1019))
+(define-constant ERR_CLAIM_IN_WRONG_CONTRACT (err u1020))
+(define-constant ERR_BLOCK_HEIGHT_IN_PAST (err u1021))
+(define-constant ERR_COINBASE_AMOUNTS_NOT_FOUND (err u1022))
+
+;; CITY WALLET MANAGEMENT
+
+;; initial value for city wallet, set to this contract until initialized
+(define-data-var cityWallet principal 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-core-v2)
+
+;; returns set city wallet principal
+(define-read-only (get-city-wallet)
+  (var-get cityWallet)
+)
+ 
+;; protected function to update city wallet variable
+(define-public (set-city-wallet (newCityWallet principal))
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (ok (var-set cityWallet newCityWallet))
+  )
+)
+
+;; REGISTRATION
+
+(define-constant MIAMICOIN_ACTIVATION_HEIGHT u24497)
+(define-data-var activationBlock uint u340282366920938463463374607431768211455)
+(define-data-var activationDelay uint u1) ;; TESTNET: set to 1 block
+(define-data-var activationReached bool false)
+(define-data-var activationTarget uint u0)
+(define-data-var activationThreshold uint u2) ;; TESTNET: set to 2 users
+(define-data-var usersNonce uint u0)
+
+;; returns Stacks block height registration was activated at plus activationDelay
+(define-read-only (get-activation-block)
+  (begin
+    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (ok (var-get activationBlock))
+  )
+)
+
+;; returns activation delay
+(define-read-only (get-activation-delay)
+  (var-get activationDelay)
+)
+
+;; returns activation status as boolean
+(define-read-only (get-activation-status)
+  (var-get activationReached)
+)
+
+;; returns activation target
+(define-read-only (get-activation-target)
+  (begin
+    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (ok (var-get activationTarget))
+  )
+)
+
+;; returns activation threshold
+(define-read-only (get-activation-threshold)
+  (var-get activationThreshold)
+)
+
+;; returns number of registered users, used for activation and tracking user IDs
+(define-read-only (get-registered-users-nonce)
+  (var-get usersNonce)
+)
+
+;; store user principal by user id
+(define-map Users
+  uint
+  principal
+)
+
+;; store user id by user principal
+(define-map UserIds
+  principal
+  uint
+)
+
+;; returns (some userId) or none
+(define-read-only (get-user-id (user principal))
+  (map-get? UserIds user)
+)
+
+;; returns (some userPrincipal) or none
+(define-read-only (get-user (userId uint))
+  (map-get? Users userId)
+)
+
+;; returns user ID if it has been created, or creates and returns new ID
+(define-private (get-or-create-user-id (user principal))
+  (match
+    (map-get? UserIds user)
+    value value
+    (let
+      (
+        (newId (+ u1 (var-get usersNonce)))
+      )
+      (map-set Users newId user)
+      (map-set UserIds user newId)
+      (var-set usersNonce newId)
+      newId
+    )
+  )
+)
+
+;; registers users that signal activation of contract until threshold is met
+(define-public (register-user (memo (optional (string-utf8 50))))
+  (let
+    (
+      (newId (+ u1 (var-get usersNonce)))
+      (threshold (var-get activationThreshold))
+      (initialized (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2 is-initialized))
+    )
+
+    (asserts! initialized ERR_UNAUTHORIZED)
+
+    (asserts! (is-none (map-get? UserIds tx-sender))
+      ERR_USER_ALREADY_REGISTERED)
+
+    (asserts! (<= newId threshold)
+      ERR_ACTIVATION_THRESHOLD_REACHED)
+
+    (if (is-some memo)
+      (print memo)
+      none
+    )
+
+    (get-or-create-user-id tx-sender)
+
+    (if (is-eq newId threshold)
+      (let
+        (
+          (activationTargetBlock (+ block-height (var-get activationDelay)))
+        )
+        (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2 activate-core-contract (as-contract tx-sender) activationTargetBlock))
+        (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 activate-token (as-contract tx-sender) MIAMICOIN_ACTIVATION_HEIGHT))
+        (try! (set-coinbase-thresholds))
+        (try! (set-coinbase-amounts))
+        (var-set activationReached true)
+        (var-set activationBlock MIAMICOIN_ACTIVATION_HEIGHT)
+        (var-set activationTarget activationTargetBlock)
+        (ok true)
+      )
+      (ok true)
+    )
+  )
+)
+
+;; MINING CONFIGURATION
+
+;; define split to custodied wallet address for the city
+(define-constant SPLIT_CITY_PCT u30)
+
+;; how long a miner must wait before block winner can claim their minted tokens
+(define-data-var tokenRewardMaturity uint u10) ;; TESTNET: set to 10 blocks
+
+;; At a given Stacks block height:
+;; - how many miners were there
+;; - what was the total amount submitted
+;; - what was the total amount submitted to the city
+;; - what was the total amount submitted to Stackers
+;; - was the block reward claimed
+(define-map MiningStatsAtBlock
+  uint
+  {
+    minersCount: uint,
+    amount: uint,
+    amountToCity: uint,
+    amountToStackers: uint,
+    rewardClaimed: bool
+  }
+)
+
+;; returns map MiningStatsAtBlock at a given Stacks block height if it exists
+(define-read-only (get-mining-stats-at-block (stacksHeight uint))
+  (map-get? MiningStatsAtBlock stacksHeight)
+)
+
+;; returns map MiningStatsAtBlock at a given Stacks block height
+;; or, an empty structure
+(define-read-only (get-mining-stats-at-block-or-default (stacksHeight uint))
+  (default-to {
+      minersCount: u0,
+      amount: u0,
+      amountToCity: u0,
+      amountToStackers: u0,
+      rewardClaimed: false
+    }
+    (map-get? MiningStatsAtBlock stacksHeight)
+  )
+)
+
+;; At a given Stacks block height and user ID:
+;; - what is their ustx commitment
+;; - what are the low/high values (used for VRF)
+(define-map MinersAtBlock
+  {
+    stacksHeight: uint,
+    userId: uint
+  }
+  {
+    ustx: uint,
+    lowValue: uint,
+    highValue: uint,
+    winner: bool
+  }
+)
+
+;; returns true if a given miner has already mined at a given block height
+(define-read-only (has-mined-at-block (stacksHeight uint) (userId uint))
+  (is-some 
+    (map-get? MinersAtBlock { stacksHeight: stacksHeight, userId: userId })
+  )
+)
+
+;; returns map MinersAtBlock at a given Stacks block height for a user ID
+(define-read-only (get-miner-at-block (stacksHeight uint) (userId uint))
+  (map-get? MinersAtBlock { stacksHeight: stacksHeight, userId: userId })
+)
+
+;; returns map MinersAtBlock at a given Stacks block height for a user ID
+;; or, an empty structure
+(define-read-only (get-miner-at-block-or-default (stacksHeight uint) (userId uint))
+  (default-to {
+    highValue: u0,
+    lowValue: u0,
+    ustx: u0,
+    winner: false
+  }
+    (map-get? MinersAtBlock { stacksHeight: stacksHeight, userId: userId }))
+)
+
+;; At a given Stacks block height:
+;; - what is the max highValue from MinersAtBlock (used for VRF)
+(define-map MinersAtBlockHighValue
+  uint
+  uint
+)
+
+;; returns last high value from map MinersAtBlockHighValue
+(define-read-only (get-last-high-value-at-block (stacksHeight uint))
+  (default-to u0
+    (map-get? MinersAtBlockHighValue stacksHeight))
+)
+
+;; At a given Stacks block height:
+;; - what is the userId of miner who won this block
+(define-map BlockWinnerIds
+  uint
+  uint
+)
+
+(define-read-only (get-block-winner-id (stacksHeight uint))
+  (map-get? BlockWinnerIds stacksHeight)
+)
+
+;; MINING ACTIONS
+
+(define-public (mine-tokens (amountUstx uint) (memo (optional (buff 34))))
+  (let
+    (
+      (userId (get-or-create-user-id tx-sender))
+    )
+    (try! (mine-tokens-at-block userId block-height amountUstx memo))
+    (ok true)
+  )
+)
+
+(define-public (mine-many (amounts (list 200 uint)))
+  (begin
+    (asserts! (is-activated) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (> (len amounts) u0) ERR_INSUFFICIENT_COMMITMENT)
+    (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
+      okReturn 
+      (begin
+        (asserts! (>= (stx-get-balance tx-sender) (+ (get toStackers okReturn) (get toCity okReturn))) ERR_INSUFFICIENT_BALANCE)
+        (if (> (get toStackers okReturn ) u0)
+          (try! (stx-transfer? (get toStackers okReturn ) tx-sender (as-contract tx-sender)))
+          false
+        )
+        (try! (stx-transfer? (get toCity okReturn) tx-sender (var-get cityWallet)))
+        (print { 
+          firstBlock: block-height, 
+          lastBlock: (- (+ block-height (len amounts)) u1) 
+        })
+        (ok true)
+      )
+      errReturn (err errReturn)
+    )
+  )
+)
+
+(define-private (mine-single 
+  (amountUstx uint) 
+  (return (response 
+    { 
+      userId: uint,
+      toStackers: uint,
+      toCity: uint,
+      stacksHeight: uint
+    }
+    uint
+  )))
+
+  (match return okReturn
+    (let
+      (
+        (stacksHeight (get stacksHeight okReturn))
+        (rewardCycle (default-to u0 (get-reward-cycle stacksHeight)))
+        (stackingActive (stacking-active-at-cycle rewardCycle))
+        (toCity
+          (if stackingActive
+            (/ (* SPLIT_CITY_PCT amountUstx) u100)
+            amountUstx
+          )
+        )
+        (toStackers (- amountUstx toCity))
+      )
+      (asserts! (not (has-mined-at-block stacksHeight (get userId okReturn))) ERR_USER_ALREADY_MINED)
+      (asserts! (> amountUstx u0) ERR_INSUFFICIENT_COMMITMENT)
+      (try! (set-tokens-mined (get userId okReturn) stacksHeight amountUstx toStackers toCity))
+      (ok (merge okReturn 
+        {
+          toStackers: (+ (get toStackers okReturn) toStackers),
+          toCity: (+ (get toCity okReturn) toCity),
+          stacksHeight: (+ stacksHeight u1)
+        }
+      ))
+    )
+    errReturn (err errReturn)
+  ) 
+)
+
+(define-private (mine-tokens-at-block (userId uint) (stacksHeight uint) (amountUstx uint) (memo (optional (buff 34))))
+  (let
+    (
+      (rewardCycle (default-to u0 (get-reward-cycle stacksHeight)))
+      (stackingActive (stacking-active-at-cycle rewardCycle))
+      (toCity
+        (if stackingActive
+          (/ (* SPLIT_CITY_PCT amountUstx) u100)
+          amountUstx
+        )
+      )
+      (toStackers (- amountUstx toCity))
+    )
+    (asserts! (is-activated) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (not (has-mined-at-block stacksHeight userId)) ERR_USER_ALREADY_MINED)
+    (asserts! (> amountUstx u0) ERR_INSUFFICIENT_COMMITMENT)
+    (asserts! (>= (stx-get-balance tx-sender) amountUstx) ERR_INSUFFICIENT_BALANCE)
+    (try! (set-tokens-mined userId stacksHeight amountUstx toStackers toCity))
+    (if (is-some memo)
+      (print memo)
+      none
+    )
+    (if stackingActive
+      (try! (stx-transfer? toStackers tx-sender (as-contract tx-sender)))
+      false
+    )
+    (try! (stx-transfer? toCity tx-sender (var-get cityWallet)))
+    (ok true)
+  )
+)
+
+(define-private (set-tokens-mined (userId uint) (stacksHeight uint) (amountUstx uint) (toStackers uint) (toCity uint))
+  (let
+    (
+      (blockStats (get-mining-stats-at-block-or-default stacksHeight))
+      (newMinersCount (+ (get minersCount blockStats) u1))
+      (minerLowVal (get-last-high-value-at-block stacksHeight))
+      (rewardCycle (unwrap! (get-reward-cycle stacksHeight)
+        ERR_STACKING_NOT_AVAILABLE))
+      (rewardCycleStats (get-stacking-stats-at-cycle-or-default rewardCycle))
+    )
+    (map-set MiningStatsAtBlock
+      stacksHeight
+      {
+        minersCount: newMinersCount,
+        amount: (+ (get amount blockStats) amountUstx),
+        amountToCity: (+ (get amountToCity blockStats) toCity),
+        amountToStackers: (+ (get amountToStackers blockStats) toStackers),
+        rewardClaimed: false
+      }
+    )
+    (map-set MinersAtBlock
+      {
+        stacksHeight: stacksHeight,
+        userId: userId
+      }
+      {
+        ustx: amountUstx,
+        lowValue: (if (> minerLowVal u0) (+ minerLowVal u1) u0),
+        highValue: (+ minerLowVal amountUstx),
+        winner: false
+      }
+    )
+    (map-set MinersAtBlockHighValue
+      stacksHeight
+      (+ minerLowVal amountUstx)
+    )
+    (if (> toStackers u0)
+      (map-set StackingStatsAtCycle
+        rewardCycle
+        {
+          amountUstx: (+ (get amountUstx rewardCycleStats) toStackers),
+          amountToken: (get amountToken rewardCycleStats)
+        }
+      )
+      false
+    )
+    (ok true)
+  )
+)
+
+;; MINING REWARD CLAIM ACTIONS
+
+;; calls function to claim mining reward in active logic contract
+(define-public (claim-mining-reward (minerBlockHeight uint))
+  (begin
+    (asserts! (or (is-eq (var-get shutdownHeight) u0) (< minerBlockHeight (var-get shutdownHeight))) ERR_CLAIM_IN_WRONG_CONTRACT)
+    (try! (claim-mining-reward-at-block tx-sender block-height minerBlockHeight))
+    (ok true)
+  )
+)
+
+;; Determine whether or not the given principal can claim the mined tokens at a particular block height,
+;; given the miners record for that block height, a random sample, and the current block height.
+(define-private (claim-mining-reward-at-block (user principal) (stacksHeight uint) (minerBlockHeight uint))
+  (let
+    (
+      (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
+      (userId (unwrap! (get-user-id user) ERR_USER_ID_NOT_FOUND))
+      (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) ERR_NO_MINERS_AT_BLOCK))
+      (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) ERR_USER_DID_NOT_MINE_IN_BLOCK))
+      (isMature (asserts! (> stacksHeight maturityHeight) ERR_CLAIMED_BEFORE_MATURITY))
+      (vrfSample (unwrap! (contract-call? 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-vrf-v2 get-save-rnd maturityHeight) ERR_NO_VRF_SEED_FOUND))
+      (commitTotal (get-last-high-value-at-block minerBlockHeight))
+      (winningValue (mod vrfSample commitTotal))
+    )
+    (asserts! (not (get rewardClaimed blockStats)) ERR_REWARD_ALREADY_CLAIMED)
+    (asserts! (and (>= winningValue (get lowValue minerStats)) (<= winningValue (get highValue minerStats)))
+      ERR_MINER_DID_NOT_WIN)
+    (try! (set-mining-reward-claimed userId minerBlockHeight))
+    (ok true)
+  )
+)
+
+(define-private (set-mining-reward-claimed (userId uint) (minerBlockHeight uint))
+  (let
+    (
+      (blockStats (get-mining-stats-at-block-or-default minerBlockHeight))
+      (minerStats (get-miner-at-block-or-default minerBlockHeight userId))
+      (user (unwrap! (get-user userId) ERR_USER_NOT_FOUND))
+    )
+    (map-set MiningStatsAtBlock
+      minerBlockHeight
+      {
+        minersCount: (get minersCount blockStats),
+        amount: (get amount blockStats),
+        amountToCity: (get amountToCity blockStats),
+        amountToStackers: (get amountToStackers blockStats),
+        rewardClaimed: true
+      }
+    )
+    (map-set MinersAtBlock
+      {
+        stacksHeight: minerBlockHeight,
+        userId: userId
+      }
+      {
+        ustx: (get ustx minerStats),
+        lowValue: (get lowValue minerStats),
+        highValue: (get highValue minerStats),
+        winner: true
+      }
+    )
+    (map-set BlockWinnerIds
+      minerBlockHeight
+      userId
+    )
+    (try! (mint-coinbase user minerBlockHeight))
+    (ok true)
+  )
+)
+
+(define-read-only (is-block-winner (user principal) (minerBlockHeight uint))
+  (is-block-winner-and-can-claim user minerBlockHeight false)
+)
+
+(define-read-only (can-claim-mining-reward (user principal) (minerBlockHeight uint))
+  (is-block-winner-and-can-claim user minerBlockHeight true)
+)
+
+(define-private (is-block-winner-and-can-claim (user principal) (minerBlockHeight uint) (testCanClaim bool))
+  (let
+    (
+      (userId (unwrap! (get-user-id user) false))
+      (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) false))
+      (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) false))
+      (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
+      (vrfSample (unwrap! (contract-call? 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-vrf-v2 get-rnd maturityHeight) false))
+      (commitTotal (get-last-high-value-at-block minerBlockHeight))
+      (winningValue (mod vrfSample commitTotal))
+    )
+    (if (and (>= winningValue (get lowValue minerStats)) (<= winningValue (get highValue minerStats)))
+      (if testCanClaim (not (get rewardClaimed blockStats)) true)
+      false
+    )
+  )
+)
+
+;; STACKING CONFIGURATION
+
+(define-constant MAX_REWARD_CYCLES u32)
+(define-constant REWARD_CYCLE_INDEXES (list u0 u1 u2 u3 u4 u5 u6 u7 u8 u9 u10 u11 u12 u13 u14 u15 u16 u17 u18 u19 u20 u21 u22 u23 u24 u25 u26 u27 u28 u29 u30 u31))
+
+;; how long a reward cycle is
+(define-data-var rewardCycleLength uint u20) ;; TESTNET: set to 20 blocks
+
+;; At a given reward cycle:
+;; - how many Stackers were there
+;; - what is the total uSTX submitted by miners
+;; - what is the total amount of tokens stacked
+(define-map StackingStatsAtCycle
+  uint
+  {
+    amountUstx: uint,
+    amountToken: uint
+  }
+)
+
+;; returns the total stacked tokens and committed uSTX for a given reward cycle
+(define-read-only (get-stacking-stats-at-cycle (rewardCycle uint))
+  (map-get? StackingStatsAtCycle rewardCycle)
+)
+
+;; returns the total stacked tokens and committed uSTX for a given reward cycle
+;; or, an empty structure
+(define-read-only (get-stacking-stats-at-cycle-or-default (rewardCycle uint))
+  (default-to { amountUstx: u0, amountToken: u0 }
+    (map-get? StackingStatsAtCycle rewardCycle))
+)
+
+;; At a given reward cycle and user ID:
+;; - what is the total tokens Stacked?
+;; - how many tokens should be returned? (based on Stacking period)
+(define-map StackerAtCycle
+  {
+    rewardCycle: uint,
+    userId: uint
+  }
+  {
+    amountStacked: uint,
+    toReturn: uint
+  }
+)
+
+(define-read-only (get-stacker-at-cycle (rewardCycle uint) (userId uint))
+  (map-get? StackerAtCycle { rewardCycle: rewardCycle, userId: userId })
+)
+
+(define-read-only (get-stacker-at-cycle-or-default (rewardCycle uint) (userId uint))
+  (default-to { amountStacked: u0, toReturn: u0 }
+    (map-get? StackerAtCycle { rewardCycle: rewardCycle, userId: userId }))
+)
+
+;; get the reward cycle for a given Stacks block height
+(define-read-only (get-reward-cycle (stacksHeight uint))
+  (let
+    (
+      (firstStackingBlock (var-get activationBlock))
+      (rcLen (var-get rewardCycleLength))
+    )
+    (if (>= stacksHeight firstStackingBlock)
+      (some (/ (- stacksHeight firstStackingBlock) rcLen))
+      none)
+  )
+)
+
+;; determine if stacking is active in a given cycle
+(define-read-only (stacking-active-at-cycle (rewardCycle uint))
+  (is-some
+    (get amountToken (map-get? StackingStatsAtCycle rewardCycle))
+  )
+)
+
+;; get the first Stacks block height for a given reward cycle.
+(define-read-only (get-first-stacks-block-in-reward-cycle (rewardCycle uint))
+  (+ (var-get activationBlock) (* (var-get rewardCycleLength) rewardCycle))
+)
+
+;; getter for get-entitled-stacking-reward that specifies block height
+(define-read-only (get-stacking-reward (userId uint) (targetCycle uint))
+  (get-entitled-stacking-reward userId targetCycle block-height)
+)
+
+;; get uSTX a Stacker can claim, given reward cycle they stacked in and current block height
+;; this method only returns a positive value if:
+;; - the current block height is in a subsequent reward cycle
+;; - the stacker actually locked up tokens in the target reward cycle
+;; - the stacker locked up _enough_ tokens to get at least one uSTX
+;; it is possible to Stack tokens and not receive uSTX:
+;; - if no miners commit during this reward cycle
+;; - the amount stacked by user is too few that you'd be entitled to less than 1 uSTX
+(define-private (get-entitled-stacking-reward (userId uint) (targetCycle uint) (stacksHeight uint))
+  (let
+    (
+      (rewardCycleStats (get-stacking-stats-at-cycle-or-default targetCycle))
+      (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle userId))
+      (totalUstxThisCycle (get amountUstx rewardCycleStats))
+      (totalStackedThisCycle (get amountToken rewardCycleStats))
+      (userStackedThisCycle (get amountStacked stackerAtCycle))
+    )
+    (match (get-reward-cycle stacksHeight)
+      currentCycle
+      (if (and (not (var-get isShutdown)) 
+        (or (<= currentCycle targetCycle) (is-eq u0 userStackedThisCycle)))
+        ;; the contract is not shut down and
+        ;; this cycle hasn't finished
+        ;; or stacker contributed nothing
+        u0
+        ;; (totalUstxThisCycle * userStackedThisCycle) / totalStackedThisCycle
+        (/ (* totalUstxThisCycle userStackedThisCycle) totalStackedThisCycle)
+      )
+      ;; before first reward cycle
+      u0
+    )
+  )
+)
+
+;; STACKING ACTIONS
+
+(define-public (stack-tokens (amountTokens uint) (lockPeriod uint))
+  (let
+    (
+      (userId (get-or-create-user-id tx-sender))
+    )
+    (try! (stack-tokens-at-cycle tx-sender userId amountTokens block-height lockPeriod))
+    (ok true)
+  )
+)
+
+(define-private (stack-tokens-at-cycle (user principal) (userId uint) (amountTokens uint) (startHeight uint) (lockPeriod uint))
+  (let
+    (
+      (currentCycle (unwrap! (get-reward-cycle startHeight) ERR_STACKING_NOT_AVAILABLE))
+      (targetCycle (+ u1 currentCycle))
+      (commitment {
+        stackerId: userId,
+        amount: amountTokens,
+        first: targetCycle,
+        last: (+ targetCycle lockPeriod)
+      })
+    )
+    (asserts! (is-activated) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (and (> lockPeriod u0) (<= lockPeriod MAX_REWARD_CYCLES))
+      ERR_CANNOT_STACK)
+    (asserts! (> amountTokens u0) ERR_CANNOT_STACK)
+    (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 transfer amountTokens tx-sender (as-contract tx-sender) none))
+    (print {
+      firstCycle: targetCycle, 
+      lastCycle: (- (+ targetCycle lockPeriod) u1)
+    })
+    (match (fold stack-tokens-closure REWARD_CYCLE_INDEXES (ok commitment))
+      okValue (ok true)
+      errValue (err errValue)
+    )
+  )
+)
+
+(define-private (stack-tokens-closure (rewardCycleIdx uint)
+  (commitmentResponse (response 
+    {
+      stackerId: uint,
+      amount: uint,
+      first: uint,
+      last: uint
+    }
+    uint
+  )))
+
+  (match commitmentResponse
+    commitment 
+    (let
+      (
+        (stackerId (get stackerId commitment))
+        (amountToken (get amount commitment))
+        (firstCycle (get first commitment))
+        (lastCycle (get last commitment))
+        (targetCycle (+ firstCycle rewardCycleIdx))
+      )
+      (begin
+        (if (and (>= targetCycle firstCycle) (< targetCycle lastCycle))
+          (begin
+            (if (is-eq targetCycle (- lastCycle u1))
+              (set-tokens-stacked stackerId targetCycle amountToken amountToken)
+              (set-tokens-stacked stackerId targetCycle amountToken u0)
+            )
+            true
+          )
+          false
+        )
+        commitmentResponse
+      )
+    )
+    errValue commitmentResponse
+  )
+)
+
+(define-private (set-tokens-stacked (userId uint) (targetCycle uint) (amountStacked uint) (toReturn uint))
+  (let
+    (
+      (rewardCycleStats (get-stacking-stats-at-cycle-or-default targetCycle))
+      (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle userId))
+    )
+    (map-set StackingStatsAtCycle
+      targetCycle
+      {
+        amountUstx: (get amountUstx rewardCycleStats),
+        amountToken: (+ amountStacked (get amountToken rewardCycleStats))
+      }
+    )
+    (map-set StackerAtCycle
+      {
+        rewardCycle: targetCycle,
+        userId: userId
+      }
+      {
+        amountStacked: (+ amountStacked (get amountStacked stackerAtCycle)),
+        toReturn: (+ toReturn (get toReturn stackerAtCycle))
+      }
+    )
+  )
+)
+
+;; STACKING REWARD CLAIMS
+
+;; calls function to claim stacking reward in active logic contract
+(define-public (claim-stacking-reward (targetCycle uint))
+  (begin
+    (try! (claim-stacking-reward-at-cycle tx-sender block-height targetCycle))
+    (ok true)
+  )
+)
+
+(define-private (claim-stacking-reward-at-cycle (user principal) (stacksHeight uint) (targetCycle uint))
+  (let
+    (
+      (currentCycle (unwrap! (get-reward-cycle stacksHeight) ERR_STACKING_NOT_AVAILABLE))
+      (userId (unwrap! (get-user-id user) ERR_USER_ID_NOT_FOUND))
+      (entitledUstx (get-entitled-stacking-reward userId targetCycle stacksHeight))
+      (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle userId))
+      (toReturn (get toReturn stackerAtCycle))
+    )
+    (asserts! (or
+      (is-eq true (var-get isShutdown))
+      (> currentCycle targetCycle))
+      ERR_REWARD_CYCLE_NOT_COMPLETED)
+    (asserts! (or (> toReturn u0) (> entitledUstx u0)) ERR_NOTHING_TO_REDEEM)
+    ;; disable ability to claim again
+    (map-set StackerAtCycle
+      {
+        rewardCycle: targetCycle,
+        userId: userId
+      }
+      {
+        amountStacked: u0,
+        toReturn: u0
+      }
+    )
+    ;; send back tokens if user was eligible
+    (if (> toReturn u0)
+      (try! (as-contract (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 transfer toReturn tx-sender user none)))
+      true
+    )
+    ;; send back rewards if user was eligible
+    (if (> entitledUstx u0)
+      (try! (as-contract (stx-transfer? entitledUstx tx-sender user)))
+      true
+    )
+    (ok true)
+  )
+)
+
+;; TOKEN CONFIGURATION
+
+;; decimals and multiplier for token
+(define-constant DECIMALS u6)
+(define-constant MICRO_CITYCOINS (pow u10 DECIMALS))
+
+;; bonus period length for increased coinbase rewards
+(define-constant TOKEN_BONUS_PERIOD u10000)
+
+;; coinbase thresholds per halving, used to determine halvings
+(define-data-var coinbaseThreshold1 uint u0)
+(define-data-var coinbaseThreshold2 uint u0)
+(define-data-var coinbaseThreshold3 uint u0)
+(define-data-var coinbaseThreshold4 uint u0)
+(define-data-var coinbaseThreshold5 uint u0)
+
+;; return coinbase thresholds if contract activated
+(define-read-only (get-coinbase-thresholds)
+  (let
+    (
+      (activated (get-activation-status))
+    )
+    (asserts! activated ERR_CONTRACT_NOT_ACTIVATED)
+    (ok {
+      coinbaseThreshold1: (var-get coinbaseThreshold1),
+      coinbaseThreshold2: (var-get coinbaseThreshold2),
+      coinbaseThreshold3: (var-get coinbaseThreshold3),
+      coinbaseThreshold4: (var-get coinbaseThreshold4),
+      coinbaseThreshold5: (var-get coinbaseThreshold5)
+    })
+  )
+)
+
+;; set coinbase thresholds, used during activation
+(define-private (set-coinbase-thresholds)
+  (let
+    (
+      (coinbaseThresholds (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 get-coinbase-thresholds)))
+    )
+    (var-set coinbaseThreshold1 (get coinbaseThreshold1 coinbaseThresholds))
+    (var-set coinbaseThreshold2 (get coinbaseThreshold2 coinbaseThresholds))
+    (var-set coinbaseThreshold3 (get coinbaseThreshold3 coinbaseThresholds))
+    (var-set coinbaseThreshold4 (get coinbaseThreshold4 coinbaseThresholds))
+    (var-set coinbaseThreshold5 (get coinbaseThreshold5 coinbaseThresholds))
+    ;; print coinbase thresholds
+    (print {
+      coinbaseThreshold1: (var-get coinbaseThreshold1),
+      coinbaseThreshold2: (var-get coinbaseThreshold2),
+      coinbaseThreshold3: (var-get coinbaseThreshold3),
+      coinbaseThreshold4: (var-get coinbaseThreshold4),
+      coinbaseThreshold5: (var-get coinbaseThreshold5)
+    })
+    (ok true)
+  )
+)
+
+;; guarded function for auth to update coinbase thresholds
+(define-public (update-coinbase-thresholds)
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (try! (set-coinbase-thresholds))
+    (ok true)
+  )
+)
+
+;; coinbase rewards per threshold, used to determine rewards
+(define-data-var coinbaseAmountBonus uint u0)
+(define-data-var coinbaseAmount1 uint u0)
+(define-data-var coinbaseAmount2 uint u0)
+(define-data-var coinbaseAmount3 uint u0)
+(define-data-var coinbaseAmount4 uint u0)
+(define-data-var coinbaseAmount5 uint u0)
+(define-data-var coinbaseAmountDefault uint u0)
+
+;; return coinbase amounts if contract activated
+(define-read-only (get-coinbase-amounts)
+  (let
+    (
+      (activated (get-activation-status))
+    )
+    (asserts! activated ERR_CONTRACT_NOT_ACTIVATED)
+    (ok {
+      coinbaseAmountBonus: (var-get coinbaseAmountBonus),
+      coinbaseAmount1: (var-get coinbaseAmount1),
+      coinbaseAmount2: (var-get coinbaseAmount2),
+      coinbaseAmount3: (var-get coinbaseAmount3),
+      coinbaseAmount4: (var-get coinbaseAmount4),
+      coinbaseAmount5: (var-get coinbaseAmount5),
+      coinbaseAmountDefault: (var-get coinbaseAmountDefault)
+    })
+  )
+)
+
+;; set coinbase amounts, used during activation
+(define-private (set-coinbase-amounts)
+  (let
+    (
+      (coinbaseAmounts (unwrap! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 get-coinbase-amounts) ERR_COINBASE_AMOUNTS_NOT_FOUND))
+    )
+    (var-set coinbaseAmountBonus (get coinbaseAmountBonus coinbaseAmounts))
+    (var-set coinbaseAmount1 (get coinbaseAmount1 coinbaseAmounts))
+    (var-set coinbaseAmount2 (get coinbaseAmount2 coinbaseAmounts))
+    (var-set coinbaseAmount3 (get coinbaseAmount3 coinbaseAmounts))
+    (var-set coinbaseAmount4 (get coinbaseAmount4 coinbaseAmounts))
+    (var-set coinbaseAmount5 (get coinbaseAmount5 coinbaseAmounts))
+    (var-set coinbaseAmountDefault (get coinbaseAmountDefault coinbaseAmounts))
+    ;; print coinbase amounts
+    (print {
+      coinbaseAmountBonus: (var-get coinbaseAmountBonus),
+      coinbaseAmount1: (var-get coinbaseAmount1),
+      coinbaseAmount2: (var-get coinbaseAmount2),
+      coinbaseAmount3: (var-get coinbaseAmount3),
+      coinbaseAmount4: (var-get coinbaseAmount4),
+      coinbaseAmount5: (var-get coinbaseAmount5),
+      coinbaseAmountDefault: (var-get coinbaseAmountDefault)
+    })
+    (ok true)
+  )
+)
+
+;; guarded function for auth to update coinbase amounts
+(define-public (update-coinbase-amounts)
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (try! (set-coinbase-amounts))
+    (ok true)
+  )
+)
+
+;; function for deciding how many tokens to mint, depending on when they were mined
+(define-read-only (get-coinbase-amount (minerBlockHeight uint))
+  (begin
+    ;; if contract is not active, return 0
+    (asserts! (>= minerBlockHeight (var-get activationBlock)) u0)
+    ;; if contract is active, return based on emissions schedule
+    ;; defined in CCIP-008 https://github.com/citycoins/governance
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold1))
+      (if (<= (- minerBlockHeight (var-get activationBlock)) TOKEN_BONUS_PERIOD)
+        ;; bonus reward for initial miners
+        (var-get coinbaseAmountBonus)
+        ;; standard reward until 1st halving
+        (var-get coinbaseAmount1)
+      )
+    )
+    ;; computations based on each halving threshold
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold2)) (var-get coinbaseAmount2))
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold3)) (var-get coinbaseAmount3))
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold4)) (var-get coinbaseAmount4))
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold5)) (var-get coinbaseAmount5))
+    ;; default value after 5th halving
+    (var-get coinbaseAmountDefault)
+  )
+)
+
+;; mint new tokens for claimant who won at given Stacks block height
+(define-private (mint-coinbase (recipient principal) (stacksHeight uint))
+  (as-contract (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 mint (get-coinbase-amount stacksHeight) recipient))
+)
+
+;; UTILITIES
+
+(define-data-var shutdownHeight uint u0)
+(define-data-var isShutdown bool false)
+
+;; stop mining and stacking operations
+;; in preparation for a core upgrade
+(define-public (shutdown-contract (stacksHeight uint))
+  (begin
+    ;; make sure block height is in the future
+    (asserts! (>= stacksHeight block-height) ERR_BLOCK_HEIGHT_IN_PAST)
+    ;; only allow shutdown request from AUTH
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    ;; set variables to disable mining/stacking in CORE
+    (var-set activationReached false)
+    (var-set shutdownHeight stacksHeight)
+    ;; set variable to allow for all stacking claims
+    (var-set isShutdown true)
+    (ok true)
+  )
+)
+
+;; checks if caller is Auth contract
+(define-private (is-authorized-auth)
+  (is-eq contract-caller 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2)
+)
+
+;; checks if contract is fully activated to
+;; enable mining and stacking functions
+(define-private (is-activated)
+  (and (get-activation-status) (>= block-height (var-get activationTarget)))
+)

--- a/contracts/legacy/miamicoin-core-v2.clar
+++ b/contracts/legacy/miamicoin-core-v2.clar
@@ -35,7 +35,7 @@
 ;; CITY WALLET MANAGEMENT
 
 ;; initial value for city wallet, set to this contract until initialized
-(define-data-var cityWallet principal 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-core-v2)
+(define-data-var cityWallet principal .miamicoin-core-v2)
 
 ;; returns set city wallet principal
 (define-read-only (get-city-wallet)
@@ -141,7 +141,7 @@
     (
       (newId (+ u1 (var-get usersNonce)))
       (threshold (var-get activationThreshold))
-      (initialized (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2 is-initialized))
+      (initialized (contract-call? .miamicoin-auth-v2 is-initialized))
     )
 
     (asserts! initialized ERR_UNAUTHORIZED)
@@ -164,8 +164,8 @@
         (
           (activationTargetBlock (+ block-height (var-get activationDelay)))
         )
-        (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2 activate-core-contract (as-contract tx-sender) activationTargetBlock))
-        (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 activate-token (as-contract tx-sender) MIAMICOIN_ACTIVATION_HEIGHT))
+        (try! (contract-call? .miamicoin-auth-v2 activate-core-contract (as-contract tx-sender) activationTargetBlock))
+        (try! (contract-call? .miamicoin-token-v2 activate-token (as-contract tx-sender) MIAMICOIN_ACTIVATION_HEIGHT))
         (try! (set-coinbase-thresholds))
         (try! (set-coinbase-amounts))
         (var-set activationReached true)
@@ -465,7 +465,7 @@
       (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) ERR_NO_MINERS_AT_BLOCK))
       (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) ERR_USER_DID_NOT_MINE_IN_BLOCK))
       (isMature (asserts! (> stacksHeight maturityHeight) ERR_CLAIMED_BEFORE_MATURITY))
-      (vrfSample (unwrap! (contract-call? 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-vrf-v2 get-save-rnd maturityHeight) ERR_NO_VRF_SEED_FOUND))
+      (vrfSample (unwrap! (contract-call? .citycoin-vrf-v2 get-save-rnd maturityHeight) ERR_NO_VRF_SEED_FOUND))
       (commitTotal (get-last-high-value-at-block minerBlockHeight))
       (winningValue (mod vrfSample commitTotal))
     )
@@ -530,7 +530,7 @@
       (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) false))
       (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) false))
       (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
-      (vrfSample (unwrap! (contract-call? 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-vrf-v2 get-rnd maturityHeight) false))
+      (vrfSample (unwrap! (contract-call? .citycoin-vrf-v2 get-rnd maturityHeight) false))
       (commitTotal (get-last-high-value-at-block minerBlockHeight))
       (winningValue (mod vrfSample commitTotal))
     )
@@ -688,7 +688,7 @@
     (asserts! (and (> lockPeriod u0) (<= lockPeriod MAX_REWARD_CYCLES))
       ERR_CANNOT_STACK)
     (asserts! (> amountTokens u0) ERR_CANNOT_STACK)
-    (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 transfer amountTokens tx-sender (as-contract tx-sender) none))
+    (try! (contract-call? .miamicoin-token-v2 transfer amountTokens tx-sender (as-contract tx-sender) none))
     (print {
       firstCycle: targetCycle, 
       lastCycle: (- (+ targetCycle lockPeriod) u1)
@@ -802,7 +802,7 @@
     )
     ;; send back tokens if user was eligible
     (if (> toReturn u0)
-      (try! (as-contract (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 transfer toReturn tx-sender user none)))
+      (try! (as-contract (contract-call? .miamicoin-token-v2 transfer toReturn tx-sender user none)))
       true
     )
     ;; send back rewards if user was eligible
@@ -851,7 +851,7 @@
 (define-private (set-coinbase-thresholds)
   (let
     (
-      (coinbaseThresholds (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 get-coinbase-thresholds)))
+      (coinbaseThresholds (try! (contract-call? .miamicoin-token-v2 get-coinbase-thresholds)))
     )
     (var-set coinbaseThreshold1 (get coinbaseThreshold1 coinbaseThresholds))
     (var-set coinbaseThreshold2 (get coinbaseThreshold2 coinbaseThresholds))
@@ -911,7 +911,7 @@
 (define-private (set-coinbase-amounts)
   (let
     (
-      (coinbaseAmounts (unwrap! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 get-coinbase-amounts) ERR_COINBASE_AMOUNTS_NOT_FOUND))
+      (coinbaseAmounts (unwrap! (contract-call? .miamicoin-token-v2 get-coinbase-amounts) ERR_COINBASE_AMOUNTS_NOT_FOUND))
     )
     (var-set coinbaseAmountBonus (get coinbaseAmountBonus coinbaseAmounts))
     (var-set coinbaseAmount1 (get coinbaseAmount1 coinbaseAmounts))
@@ -970,7 +970,7 @@
 
 ;; mint new tokens for claimant who won at given Stacks block height
 (define-private (mint-coinbase (recipient principal) (stacksHeight uint))
-  (as-contract (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-token-v2 mint (get-coinbase-amount stacksHeight) recipient))
+  (as-contract (contract-call? .miamicoin-token-v2 mint (get-coinbase-amount stacksHeight) recipient))
 )
 
 ;; UTILITIES
@@ -997,7 +997,7 @@
 
 ;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
-  (is-eq contract-caller 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2)
+  (is-eq contract-caller .miamicoin-auth-v2)
 )
 
 ;; checks if contract is fully activated to

--- a/contracts/legacy/miamicoin-core-v2.clar
+++ b/contracts/legacy/miamicoin-core-v2.clar
@@ -3,7 +3,7 @@
 
 ;; GENERAL CONFIGURATION
 
-(impl-trait 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-core-v2-trait.citycoin-core-v2)
+(impl-trait .citycoin-core-v2-trait.citycoin-core-v2)
 (define-constant CONTRACT_OWNER tx-sender)
 
 ;; ERROR CODES

--- a/contracts/legacy/miamicoin-token-v2.clar
+++ b/contracts/legacy/miamicoin-token-v2.clar
@@ -1,0 +1,281 @@
+;; MIAMICOIN TOKEN V2 CONTRACT TESTNET
+;; CityCoins Protocol Version 2.0.0
+
+;; TRAIT DEFINITIONS
+
+(impl-trait 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-token-v2-trait.citycoin-token-v2)
+
+;; ERROR CODES
+
+(define-constant ERR_UNAUTHORIZED (err u2000))
+(define-constant ERR_TOKEN_NOT_ACTIVATED (err u2001))
+(define-constant ERR_TOKEN_ALREADY_ACTIVATED (err u2002))
+(define-constant ERR_V1_BALANCE_NOT_FOUND (err u2003))
+(define-constant ERR_INVALID_COINBASE_THRESHOLD (err u2004))
+(define-constant ERR_INVALID_COINBASE_AMOUNT (err u2005))
+
+;; SIP-010 DEFINITION
+
+(impl-trait 'ST1NXBK3K5YYMD6FD41MVNP3JS1GABZ8TRVX023PT.sip-010-trait-ft-standard.sip-010-trait)
+
+(define-fungible-token miamicoin)
+
+(define-constant DECIMALS u6)
+(define-constant MICRO_CITYCOINS (pow u10 DECIMALS))
+
+;; SIP-010 FUNCTIONS
+
+(define-public (transfer (amount uint) (from principal) (to principal) (memo (optional (buff 34))))
+  (begin
+    (asserts! (is-eq from tx-sender) ERR_UNAUTHORIZED)
+    (if (is-some memo)
+      (print memo)
+      none
+    )
+    (ft-transfer? miamicoin amount from to)
+  )
+)
+
+(define-read-only (get-name)
+  (ok "miamicoin")
+)
+
+(define-read-only (get-symbol)
+  (ok "MIA")
+)
+
+(define-read-only (get-decimals)
+  (ok DECIMALS)
+)
+
+(define-read-only (get-balance (user principal))
+  (ok (ft-get-balance miamicoin user))
+)
+
+(define-read-only (get-total-supply)
+  (ok (ft-get-supply miamicoin))
+)
+
+(define-read-only (get-token-uri)
+  (ok (var-get tokenUri))
+)
+
+;; TOKEN CONFIGURATION
+
+;; define bonus period and initial epoch length
+(define-constant TOKEN_BONUS_PERIOD u10000)
+(define-constant TOKEN_EPOCH_LENGTH u25000)
+
+;; once activated, activation cannot happen again
+(define-data-var tokenActivated bool false)
+
+;; core contract states
+(define-constant STATE_DEPLOYED u0)
+(define-constant STATE_ACTIVE u1)
+(define-constant STATE_INACTIVE u2)
+
+;; one-time function to activate the token
+(define-public (activate-token (coreContract principal) (stacksHeight uint))
+  (let
+    (
+      (coreContractMap (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2 get-core-contract-info coreContract)))
+      (threshold1 (+ stacksHeight TOKEN_BONUS_PERIOD TOKEN_EPOCH_LENGTH))         ;; 35,000 blocks
+      (threshold2 (+ stacksHeight TOKEN_BONUS_PERIOD (* u3 TOKEN_EPOCH_LENGTH)))  ;; 85,000 blocks
+      (threshold3 (+ stacksHeight TOKEN_BONUS_PERIOD (* u7 TOKEN_EPOCH_LENGTH)))  ;; 185,000 blocks
+      (threshold4 (+ stacksHeight TOKEN_BONUS_PERIOD (* u15 TOKEN_EPOCH_LENGTH))) ;; 385,000 blocks
+      (threshold5 (+ stacksHeight TOKEN_BONUS_PERIOD (* u31 TOKEN_EPOCH_LENGTH))) ;; 785,000 blocks
+    )
+    (asserts! (is-eq (get state coreContractMap) STATE_ACTIVE) ERR_UNAUTHORIZED)
+    (asserts! (not (var-get tokenActivated)) ERR_TOKEN_ALREADY_ACTIVATED)
+    (var-set tokenActivated true)
+    (try! (set-coinbase-thresholds threshold1 threshold2 threshold3 threshold4 threshold5))
+    (ok true)
+  )
+)
+
+;; COINBASE THRESHOLDS
+
+;; coinbase thresholds per halving, used to select coinbase rewards in core
+;; initially set by register-user in core contract per CCIP-008
+(define-data-var coinbaseThreshold1 uint u0)
+(define-data-var coinbaseThreshold2 uint u0)
+(define-data-var coinbaseThreshold3 uint u0)
+(define-data-var coinbaseThreshold4 uint u0)
+(define-data-var coinbaseThreshold5 uint u0)
+
+;; return coinbase thresholds if token activated
+(define-read-only (get-coinbase-thresholds)
+  (let
+    (
+      (activated (var-get tokenActivated))
+    )
+    (asserts! activated ERR_TOKEN_NOT_ACTIVATED)
+    (ok {
+      coinbaseThreshold1: (var-get coinbaseThreshold1),
+      coinbaseThreshold2: (var-get coinbaseThreshold2),
+      coinbaseThreshold3: (var-get coinbaseThreshold3),
+      coinbaseThreshold4: (var-get coinbaseThreshold4),
+      coinbaseThreshold5: (var-get coinbaseThreshold5)
+    })
+  )
+)
+
+(define-private (set-coinbase-thresholds (threshold1 uint) (threshold2 uint) (threshold3 uint) (threshold4 uint) (threshold5 uint))
+  (begin
+    ;; check that all thresholds increase in value
+    (asserts! (and (> threshold1 u0) (> threshold2 threshold1) (> threshold3 threshold2) (> threshold4 threshold3) (> threshold5 threshold4)) ERR_INVALID_COINBASE_THRESHOLD)
+    ;; set coinbase thresholds
+    (var-set coinbaseThreshold1 threshold1)
+    (var-set coinbaseThreshold2 threshold2)
+    (var-set coinbaseThreshold3 threshold3)
+    (var-set coinbaseThreshold4 threshold4)
+    (var-set coinbaseThreshold5 threshold5)
+    ;; print coinbase thresholds
+    (print {
+      coinbaseThreshold1: threshold1,
+      coinbaseThreshold2: threshold2,
+      coinbaseThreshold3: threshold3,
+      coinbaseThreshold4: threshold4,
+      coinbaseThreshold5: threshold5
+    })
+    (ok true)
+  )
+)
+
+;; only accessible by auth
+(define-public (update-coinbase-thresholds (threshold1 uint) (threshold2 uint) (threshold3 uint) (threshold4 uint) (threshold5 uint))
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (asserts! (var-get tokenActivated) ERR_TOKEN_NOT_ACTIVATED)
+    (try! (set-coinbase-thresholds threshold1 threshold2 threshold3 threshold4 threshold5))
+    (ok true)
+  )
+)
+
+;; COINBASE AMOUNTS (REWARDS)
+
+;; coinbase rewards per threshold per CCIP-008
+(define-data-var coinbaseAmountBonus uint (* MICRO_CITYCOINS u250000))
+(define-data-var coinbaseAmount1 uint (* MICRO_CITYCOINS u100000))
+(define-data-var coinbaseAmount2 uint (* MICRO_CITYCOINS u50000))
+(define-data-var coinbaseAmount3 uint (* MICRO_CITYCOINS u25000))
+(define-data-var coinbaseAmount4 uint (* MICRO_CITYCOINS u12500))
+(define-data-var coinbaseAmount5 uint (* MICRO_CITYCOINS u6250))
+(define-data-var coinbaseAmountDefault uint (* MICRO_CITYCOINS u3125))
+
+;; return coinbase thresholds if token activated
+(define-read-only (get-coinbase-amounts)
+  (ok {
+    coinbaseAmountBonus: (var-get coinbaseAmountBonus),
+    coinbaseAmount1: (var-get coinbaseAmount1),
+    coinbaseAmount2: (var-get coinbaseAmount2),
+    coinbaseAmount3: (var-get coinbaseAmount3),
+    coinbaseAmount4: (var-get coinbaseAmount4),
+    coinbaseAmount5: (var-get coinbaseAmount5),
+    coinbaseAmountDefault: (var-get coinbaseAmountDefault)
+  })
+)
+
+(define-private (set-coinbase-amounts (amountBonus uint) (amount1 uint) (amount2 uint) (amount3 uint) (amount4 uint) (amount5 uint) (amountDefault uint))
+  (begin
+    ;; check that all amounts are greater than zero
+    (asserts! (and (> amountBonus u0) (> amount1 u0) (> amount2 u0) (> amount3 u0) (> amount4 u0) (> amount5 u0) (> amountDefault u0)) ERR_INVALID_COINBASE_AMOUNT)
+    ;; set coinbase amounts in token contract
+    (var-set coinbaseAmountBonus amountBonus)
+    (var-set coinbaseAmount1 amount1)
+    (var-set coinbaseAmount2 amount2)
+    (var-set coinbaseAmount3 amount3)
+    (var-set coinbaseAmount4 amount4)
+    (var-set coinbaseAmount5 amount5)
+    (var-set coinbaseAmountDefault amountDefault)
+    ;; print coinbase amounts
+    (print {
+      coinbaseAmountBonus: amountBonus,
+      coinbaseAmount1: amount1,
+      coinbaseAmount2: amount2,
+      coinbaseAmount3: amount3,
+      coinbaseAmount4: amount4,
+      coinbaseAmount5: amount5,
+      coinbaseAmountDefault: amountDefault
+    })
+    (ok true)
+  )
+)
+
+;; only accessible by auth
+(define-public (update-coinbase-amounts (amountBonus uint) (amount1 uint) (amount2 uint) (amount3 uint) (amount4 uint) (amount5 uint) (amountDefault uint))
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    ;; (asserts! (var-get tokenActivated) ERR_TOKEN_NOT_ACTIVATED)
+    (try! (set-coinbase-amounts amountBonus amount1 amount2 amount3 amount4 amount5 amountDefault))
+    (ok true)
+  )
+)
+
+;; V1 TO V2 CONVERSION
+
+;; TESTNET: convert-to-v2 removed, no v1
+
+;; UTILITIES
+
+(define-data-var tokenUri (optional (string-utf8 256)) (some u"https://cdn.citycoins.co/metadata/miamicoin.json"))
+
+;; set token URI to new value, only accessible by Auth
+(define-public (set-token-uri (newUri (optional (string-utf8 256))))
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (ok (var-set tokenUri newUri))
+  )
+)
+
+;; mint new tokens, only accessible by a Core contract
+(define-public (mint (amount uint) (recipient principal))
+  (let
+    (
+      (coreContract (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2 get-core-contract-info contract-caller)))
+    )
+    (ft-mint? miamicoin amount recipient)
+  )
+)
+
+;; burn tokens
+(define-public (burn (amount uint) (owner principal))
+  (begin
+    (asserts! (is-eq tx-sender owner) ERR_UNAUTHORIZED)
+    (ft-burn? miamicoin amount owner)
+  )
+)
+
+;; checks if caller is Auth contract
+(define-private (is-authorized-auth)
+  (is-eq contract-caller 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2)
+)
+
+;; SEND-MANY
+
+(define-public (send-many (recipients (list 200 { to: principal, amount: uint, memo: (optional (buff 34)) })))
+  (fold check-err
+    (map send-token recipients)
+    (ok true)
+  )
+)
+
+(define-private (check-err (result (response bool uint)) (prior (response bool uint)))
+  (match prior ok-value
+    result
+    err-value (err err-value)
+  )
+)
+
+(define-private (send-token (recipient { to: principal, amount: uint, memo: (optional (buff 34)) }))
+  (send-token-with-memo (get amount recipient) (get to recipient) (get memo recipient))
+)
+
+(define-private (send-token-with-memo (amount uint) (to principal) (memo (optional (buff 34))))
+  (let
+    (
+      (transferOk (try! (transfer amount tx-sender to memo)))
+    )
+    (ok transferOk)
+  )
+)

--- a/contracts/legacy/miamicoin-token-v2.clar
+++ b/contracts/legacy/miamicoin-token-v2.clar
@@ -78,7 +78,7 @@
 (define-public (activate-token (coreContract principal) (stacksHeight uint))
   (let
     (
-      (coreContractMap (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2 get-core-contract-info coreContract)))
+      (coreContractMap (try! (contract-call? .miamicoin-auth-v2 get-core-contract-info coreContract)))
       (threshold1 (+ stacksHeight TOKEN_BONUS_PERIOD TOKEN_EPOCH_LENGTH))         ;; 35,000 blocks
       (threshold2 (+ stacksHeight TOKEN_BONUS_PERIOD (* u3 TOKEN_EPOCH_LENGTH)))  ;; 85,000 blocks
       (threshold3 (+ stacksHeight TOKEN_BONUS_PERIOD (* u7 TOKEN_EPOCH_LENGTH)))  ;; 185,000 blocks
@@ -232,7 +232,7 @@
 (define-public (mint (amount uint) (recipient principal))
   (let
     (
-      (coreContract (try! (contract-call? 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2 get-core-contract-info contract-caller)))
+      (coreContract (try! (contract-call? .miamicoin-auth-v2 get-core-contract-info contract-caller)))
     )
     (ft-mint? miamicoin amount recipient)
   )
@@ -248,7 +248,7 @@
 
 ;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
-  (is-eq contract-caller 'ST1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8WRH7C6H.miamicoin-auth-v2)
+  (is-eq contract-caller .miamicoin-auth-v2)
 )
 
 ;; SEND-MANY

--- a/contracts/legacy/miamicoin-token-v2.clar
+++ b/contracts/legacy/miamicoin-token-v2.clar
@@ -3,7 +3,7 @@
 
 ;; TRAIT DEFINITIONS
 
-(impl-trait 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-token-v2-trait.citycoin-token-v2)
+(impl-trait .citycoin-token-v2-trait.citycoin-token-v2)
 
 ;; ERROR CODES
 

--- a/contracts/legacy/newyorkcitycoin-auth-v2.clar
+++ b/contracts/legacy/newyorkcitycoin-auth-v2.clar
@@ -1,0 +1,630 @@
+;; NEWYORKCITYCOIN AUTH CONTRACT V2 TESTNET
+;; CityCoins Protocol Version 2.0.0
+
+(define-constant CONTRACT_OWNER tx-sender)
+
+;; TRAIT DEFINITIONS
+
+(use-trait coreTraitV2 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-core-v2-trait.citycoin-core-v2)
+(use-trait tokenTraitV2 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-token-v2-trait.citycoin-token-v2)
+
+;; ERRORS
+
+(define-constant ERR_UNKNOWN_JOB (err u6000))
+(define-constant ERR_UNAUTHORIZED (err u6001))
+(define-constant ERR_JOB_IS_ACTIVE (err u6002))
+(define-constant ERR_JOB_IS_NOT_ACTIVE (err u6003))
+(define-constant ERR_ALREADY_VOTED_THIS_WAY (err u6004))
+(define-constant ERR_JOB_IS_EXECUTED (err u6005))
+(define-constant ERR_JOB_IS_NOT_APPROVED (err u6006))
+(define-constant ERR_ARGUMENT_ALREADY_EXISTS (err u6007))
+(define-constant ERR_NO_ACTIVE_CORE_CONTRACT (err u6008))
+(define-constant ERR_CORE_CONTRACT_NOT_FOUND (err u6009))
+(define-constant ERR_UNKNOWN_ARGUMENT (err u6010))
+(define-constant ERR_INCORRECT_CONTRACT_STATE (err u6011))
+(define-constant ERR_CONTRACT_ALREADY_EXISTS (err u6012))
+
+;; JOB MANAGEMENT
+
+(define-constant REQUIRED_APPROVALS u2) ;; TESTNET: set to 2 approvals
+
+(define-data-var lastJobId uint u0)
+
+(define-map Jobs
+  uint
+  {
+    creator: principal,
+    name: (string-ascii 255),
+    target: principal,
+    approvals: uint,
+    disapprovals: uint,
+    isActive: bool,
+    isExecuted: bool
+  }
+)
+
+(define-map JobApprovers
+  { jobId: uint, approver: principal }
+  bool
+)
+
+(define-map Approvers
+  principal
+  bool
+)
+
+(define-map ArgumentLastIdsByType
+  { jobId: uint, argumentType: (string-ascii 25) }
+  uint
+)
+
+(define-map UIntArgumentsByName
+  { jobId: uint, argumentName: (string-ascii 255) }
+  { argumentId: uint, value: uint}
+)
+
+(define-map UIntArgumentsById
+  { jobId: uint, argumentId: uint }
+  { argumentName: (string-ascii 255), value: uint }
+)
+
+(define-map PrincipalArgumentsByName
+  { jobId: uint, argumentName: (string-ascii 255) }
+  { argumentId: uint, value: principal }
+)
+
+(define-map PrincipalArgumentsById
+  { jobId: uint, argumentId: uint }
+  { argumentName: (string-ascii 255), value: principal }
+)
+
+;; FUNCTIONS
+
+(define-read-only (get-last-job-id)
+  (var-get lastJobId)
+)
+
+(define-public (create-job (name (string-ascii 255)) (target principal))
+  (let
+    (
+      (newJobId (+ (var-get lastJobId) u1))
+    )
+    (asserts! (is-approver tx-sender) ERR_UNAUTHORIZED)
+    (map-set Jobs
+      newJobId
+      {
+        creator: tx-sender,
+        name: name,
+        target: target,
+        approvals: u0,
+        disapprovals: u0,
+        isActive: false,
+        isExecuted: false
+      }
+    )
+    (var-set lastJobId newJobId)
+    (ok newJobId)
+  )
+)
+
+(define-read-only (get-job (jobId uint))
+  (map-get? Jobs jobId)
+)
+
+(define-public (activate-job (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+    )
+    (asserts! (is-eq (get creator job) tx-sender) ERR_UNAUTHORIZED)
+    (asserts! (not (get isActive job)) ERR_JOB_IS_ACTIVE)
+    (map-set Jobs 
+      jobId
+      (merge job { isActive: true })
+    )
+    (ok true)
+  )
+)
+
+(define-public (approve-job (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+      (previousVote (map-get? JobApprovers { jobId: jobId, approver: tx-sender }))
+    )
+    (asserts! (get isActive job) ERR_JOB_IS_NOT_ACTIVE)
+    (asserts! (is-approver tx-sender) ERR_UNAUTHORIZED)
+    ;; save vote
+    (map-set JobApprovers
+      { jobId: jobId, approver: tx-sender }
+      true
+    )
+    (match previousVote approved
+      (begin
+        (asserts! (not approved) ERR_ALREADY_VOTED_THIS_WAY)
+        (map-set Jobs jobId
+          (merge job 
+            {
+              approvals: (+ (get approvals job) u1),
+              disapprovals: (- (get disapprovals job) u1)
+            }
+          )
+        )
+      )
+      ;; no previous vote
+      (map-set Jobs
+        jobId
+        (merge job { approvals: (+ (get approvals job) u1) } )
+      )
+    )  
+    (ok true)
+  )
+)
+
+(define-public (disapprove-job (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+      (previousVote (map-get? JobApprovers { jobId: jobId, approver: tx-sender }))
+    )
+    (asserts! (get isActive job) ERR_JOB_IS_NOT_ACTIVE)
+    (asserts! (is-approver tx-sender) ERR_UNAUTHORIZED)
+    ;; save vote
+    (map-set JobApprovers
+      { jobId: jobId, approver: tx-sender }
+      false
+    )
+    (match previousVote approved
+      (begin
+        (asserts! approved ERR_ALREADY_VOTED_THIS_WAY)
+        (map-set Jobs jobId
+          (merge job 
+            {
+              approvals: (- (get approvals job) u1),
+              disapprovals: (+ (get disapprovals job) u1)
+            }
+          )
+        )
+      )
+      ;; no previous vote
+      (map-set Jobs
+        jobId
+        (merge job { disapprovals: (+ (get disapprovals job) u1) } )
+      )
+    )
+    (ok true)
+  )
+)
+
+(define-read-only (is-job-approved (jobId uint))
+  (match (get-job jobId) job
+    (>= (get approvals job) REQUIRED_APPROVALS)
+    false
+  )
+)
+
+(define-public (mark-job-as-executed (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+    )
+    (asserts! (get isActive job) ERR_JOB_IS_NOT_ACTIVE)
+    (asserts! (>= (get approvals job) REQUIRED_APPROVALS) ERR_JOB_IS_NOT_APPROVED)
+    (asserts! (is-eq (get target job) contract-caller) ERR_UNAUTHORIZED)
+    (asserts! (not (get isExecuted job)) ERR_JOB_IS_EXECUTED)
+    (map-set Jobs
+      jobId
+      (merge job { isExecuted: true })
+    )
+    (ok true)
+  )
+)
+
+(define-public (add-uint-argument (jobId uint) (argumentName (string-ascii 255)) (value uint))
+  (let
+    (
+      (argumentId (generate-argument-id jobId "uint"))
+    )
+    (try! (guard-add-argument jobId))
+    (asserts! 
+      (and
+        (map-insert UIntArgumentsById
+          { jobId: jobId, argumentId: argumentId }
+          { argumentName: argumentName, value: value }
+        )
+        (map-insert UIntArgumentsByName
+          { jobId: jobId, argumentName: argumentName }
+          { argumentId: argumentId, value: value}
+        )
+      ) 
+      ERR_ARGUMENT_ALREADY_EXISTS
+    )
+    (ok true)
+  )
+)
+
+(define-read-only (get-uint-argument-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (map-get? UIntArgumentsByName { jobId: jobId, argumentName: argumentName })
+)
+
+(define-read-only (get-uint-argument-by-id (jobId uint) (argumentId uint))
+  (map-get? UIntArgumentsById { jobId: jobId, argumentId: argumentId })
+)
+
+(define-read-only (get-uint-value-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (get value (get-uint-argument-by-name jobId argumentName))
+)
+
+(define-read-only (get-uint-value-by-id (jobId uint) (argumentId uint))
+  (get value (get-uint-argument-by-id jobId argumentId))
+)
+
+(define-public (add-principal-argument (jobId uint) (argumentName (string-ascii 255)) (value principal))
+  (let
+    (
+      (argumentId (generate-argument-id jobId "principal"))
+    )
+    (try! (guard-add-argument jobId))
+    (asserts! 
+      (and
+        (map-insert PrincipalArgumentsById
+          { jobId: jobId, argumentId: argumentId }
+          { argumentName: argumentName, value: value }
+        )
+        (map-insert PrincipalArgumentsByName
+          { jobId: jobId, argumentName: argumentName }
+          { argumentId: argumentId, value: value}
+        )
+      ) 
+      ERR_ARGUMENT_ALREADY_EXISTS
+    )
+    (ok true)
+  )
+)
+
+(define-read-only (get-principal-argument-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (map-get? PrincipalArgumentsByName { jobId: jobId, argumentName: argumentName })
+)
+
+(define-read-only (get-principal-argument-by-id (jobId uint) (argumentId uint))
+  (map-get? PrincipalArgumentsById { jobId: jobId, argumentId: argumentId })
+)
+
+(define-read-only (get-principal-value-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (get value (get-principal-argument-by-name jobId argumentName))
+)
+
+(define-read-only (get-principal-value-by-id (jobId uint) (argumentId uint))
+  (get value (get-principal-argument-by-id jobId argumentId))
+)
+
+;; PRIVATE FUNCTIONS
+
+(define-read-only  (is-approver (user principal))
+  (default-to false (map-get? Approvers user))
+)
+
+(define-private (generate-argument-id (jobId uint) (argumentType (string-ascii 25)))
+  (let
+    (
+      (argumentId (+ (default-to u0 (map-get? ArgumentLastIdsByType { jobId: jobId, argumentType: argumentType })) u1))
+    )
+    (map-set ArgumentLastIdsByType
+      { jobId: jobId, argumentType: argumentType }
+      argumentId
+    )
+    ;; return
+    argumentId
+  )
+)
+
+(define-private (guard-add-argument (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+    )
+    (asserts! (not (get isActive job)) ERR_JOB_IS_ACTIVE)
+    (asserts! (is-eq (get creator job) contract-caller) ERR_UNAUTHORIZED)
+    (ok true)
+  )
+)
+
+;; CONTRACT MANAGEMENT
+
+;; initial value for active core contract
+;; set to deployer address at startup to prevent
+;; circular dependency of core on auth
+(define-data-var activeCoreContract principal CONTRACT_OWNER)
+(define-data-var initialized bool false)
+
+;; core contract states
+(define-constant STATE_DEPLOYED u0)
+(define-constant STATE_ACTIVE u1)
+(define-constant STATE_INACTIVE u2)
+
+;; core contract map
+(define-map CoreContracts
+  principal
+  {
+    state: uint, 
+    startHeight: uint,
+    endHeight: uint
+  }
+)
+
+;; getter for active core contract
+(define-read-only (get-active-core-contract)
+  (begin
+    (asserts! (not (is-eq (var-get activeCoreContract) CONTRACT_OWNER)) ERR_NO_ACTIVE_CORE_CONTRACT)
+    (ok (var-get activeCoreContract))
+  )
+)
+
+;; getter for core contract map
+(define-read-only (get-core-contract-info (targetContract principal))
+  (let
+    (
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) ERR_CORE_CONTRACT_NOT_FOUND))
+    )
+    (ok coreContract)
+  )
+)
+
+;; one-time function to initialize contracts after all contracts are deployed
+;; - check that deployer is calling this function
+;; - check this contract is not activated already (one-time use)
+;; - set initial map value for core contract v1
+;; - set cityWallet in core contract
+;; - set intialized true
+(define-public (initialize-contracts (coreContract <coreTraitV2>))
+  (let
+    (
+      (coreContractAddress (contract-of coreContract))
+    )
+    (asserts! (is-eq contract-caller CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (not (var-get initialized)) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      coreContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (try! (contract-call? coreContract set-city-wallet (var-get cityWallet)))
+    (var-set initialized true)
+    (ok true)
+  )
+)
+
+(define-read-only (is-initialized)
+  (var-get initialized)
+)
+
+;; function to activate core contract through registration
+;; - check that target is in core contract map
+;; - check that caller is core contract
+;; - check that target is in STATE_DEPLOYED
+;; - set active in core contract map
+;; - set as activeCoreContract
+(define-public (activate-core-contract (targetContract principal) (stacksHeight uint))
+  (let
+    (
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) ERR_CORE_CONTRACT_NOT_FOUND))
+    )
+    (asserts! (is-eq (get state coreContract) STATE_DEPLOYED) ERR_INCORRECT_CONTRACT_STATE)
+    (asserts! (is-eq contract-caller targetContract) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      targetContract
+      {
+        state: STATE_ACTIVE,
+        startHeight: stacksHeight,
+        endHeight: u0
+      })
+    (var-set activeCoreContract targetContract)
+    (ok true)
+  )
+)
+
+;; protected function to update core contract
+(define-public (upgrade-core-contract (oldContract <coreTraitV2>) (newContract <coreTraitV2>))
+  (let
+    (
+      (oldContractAddress (contract-of oldContract))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+      (newContractAddress (contract-of newContract))
+    )
+    (asserts! (not (is-eq oldContractAddress newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (is-none (map-get? CoreContracts newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      oldContractAddress
+      {
+        state: STATE_INACTIVE,
+        startHeight: (get startHeight oldContractMap),
+        endHeight: block-height
+      })
+    (map-set CoreContracts
+      newContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (var-set activeCoreContract newContractAddress)
+    (try! (contract-call? oldContract shutdown-contract block-height))
+    (try! (contract-call? newContract set-city-wallet (var-get cityWallet)))
+    (ok true)
+  )
+)
+
+(define-public (execute-upgrade-core-contract-job (jobId uint) (oldContract <coreTraitV2>) (newContract <coreTraitV2>))
+  (let
+    (
+      (oldContractArg (unwrap! (get-principal-value-by-name jobId "oldContract") ERR_UNKNOWN_ARGUMENT))
+      (newContractArg (unwrap! (get-principal-value-by-name jobId "newContract") ERR_UNKNOWN_ARGUMENT))
+      (oldContractAddress (contract-of oldContract))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+      (newContractAddress (contract-of newContract))
+    )
+    (asserts! (not (is-eq oldContractAddress newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (is-none (map-get? CoreContracts newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (and (is-eq oldContractArg oldContractAddress) (is-eq newContractArg newContractAddress)) ERR_UNAUTHORIZED)
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      oldContractAddress
+      {
+        state: STATE_INACTIVE,
+        startHeight: (get startHeight oldContractMap),
+        endHeight: block-height
+      })
+    (map-set CoreContracts
+      newContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (var-set activeCoreContract newContractAddress)
+    (try! (contract-call? oldContract shutdown-contract block-height))
+    (try! (contract-call? newContract set-city-wallet (var-get cityWallet)))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; CITY WALLET MANAGEMENT
+
+;; initial value for city wallet
+(define-data-var cityWallet principal 'ST7G6VDV48CXXSP6J2B4RRCKTFJ5NK3PBZSD3YW5)
+
+;; returns city wallet principal
+(define-read-only (get-city-wallet)
+  (ok (var-get cityWallet))
+)
+ 
+;; protected function to update city wallet variable
+(define-public (set-city-wallet (targetContract <coreTraitV2>) (newCityWallet principal))
+  (let
+    (
+      (coreContractAddress (contract-of targetContract))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+    )
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    (asserts! (is-eq coreContractAddress (var-get activeCoreContract)) ERR_UNAUTHORIZED)
+    (var-set cityWallet newCityWallet)
+    (try! (contract-call? targetContract set-city-wallet newCityWallet))
+    (ok true)
+  )
+)
+
+(define-public (execute-set-city-wallet-job (jobId uint) (targetContract <coreTraitV2>))
+  (let
+    (
+      (coreContractAddress (contract-of targetContract))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+      (newCityWallet (unwrap! (get-principal-value-by-name jobId "newCityWallet") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (asserts! (is-eq coreContractAddress (var-get activeCoreContract)) ERR_UNAUTHORIZED)
+    (var-set cityWallet newCityWallet)
+    (try! (contract-call? targetContract set-city-wallet newCityWallet))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; check if contract caller is city wallet
+(define-private (is-authorized-city)
+  (is-eq contract-caller (var-get cityWallet))
+)
+
+;; TOKEN MANAGEMENT
+
+(define-public (set-token-uri (targetContract <tokenTraitV2>) (newUri (optional (string-utf8 256))))
+  (begin
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    (as-contract (try! (contract-call? targetContract set-token-uri newUri)))
+    (ok true)
+  )
+)
+
+;; COINBASE THRESHOLDS
+
+(define-public (update-coinbase-thresholds (targetCore <coreTraitV2>) (targetToken <tokenTraitV2>) (threshold1 uint) (threshold2 uint) (threshold3 uint) (threshold4 uint) (threshold5 uint))
+  (begin
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    ;; update in token contract
+    (as-contract (try! (contract-call? targetToken update-coinbase-thresholds threshold1 threshold2 threshold3 threshold4 threshold5)))
+    ;; update core contract based on token contract
+    (as-contract (try! (contract-call? targetCore update-coinbase-thresholds)))
+    (ok true)
+  )
+)
+
+(define-public (execute-update-coinbase-thresholds-job (jobId uint) (targetCore <coreTraitV2>) (targetToken <tokenTraitV2>))
+  (let
+    (
+      (threshold1 (unwrap! (get-uint-value-by-name jobId "threshold1") ERR_UNKNOWN_ARGUMENT))
+      (threshold2 (unwrap! (get-uint-value-by-name jobId "threshold2") ERR_UNKNOWN_ARGUMENT))
+      (threshold3 (unwrap! (get-uint-value-by-name jobId "threshold3") ERR_UNKNOWN_ARGUMENT))
+      (threshold4 (unwrap! (get-uint-value-by-name jobId "threshold4") ERR_UNKNOWN_ARGUMENT))
+      (threshold5 (unwrap! (get-uint-value-by-name jobId "threshold5") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (as-contract (try! (contract-call? targetToken update-coinbase-thresholds threshold1 threshold2 threshold3 threshold4 threshold5)))
+    (as-contract (try! (contract-call? targetCore update-coinbase-thresholds)))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; COINBASE AMOUNTS (REWARDS)
+
+(define-public (update-coinbase-amounts (targetCore <coreTraitV2>) (targetToken <tokenTraitV2>) (amountBonus uint) (amount1 uint) (amount2 uint) (amount3 uint) (amount4 uint) (amount5 uint) (amountDefault uint))
+  (begin
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    ;; update in token contract
+    (as-contract (try! (contract-call? targetToken update-coinbase-amounts amountBonus amount1 amount2 amount3 amount4 amount5 amountDefault)))
+    ;; update core contract based on token contract
+    (as-contract (try! (contract-call? targetCore update-coinbase-amounts)))
+    (ok true)
+  )
+)
+
+(define-public (execute-update-coinbase-amounts-job (jobId uint) (targetCore <coreTraitV2>) (targetToken <tokenTraitV2>))
+  (let
+    (
+      (amountBonus (unwrap! (get-uint-value-by-name jobId "amountBonus") ERR_UNKNOWN_ARGUMENT))
+      (amount1 (unwrap! (get-uint-value-by-name jobId "amount1") ERR_UNKNOWN_ARGUMENT))
+      (amount2 (unwrap! (get-uint-value-by-name jobId "amount2") ERR_UNKNOWN_ARGUMENT))
+      (amount3 (unwrap! (get-uint-value-by-name jobId "amount3") ERR_UNKNOWN_ARGUMENT))
+      (amount4 (unwrap! (get-uint-value-by-name jobId "amount4") ERR_UNKNOWN_ARGUMENT))
+      (amount5 (unwrap! (get-uint-value-by-name jobId "amount5") ERR_UNKNOWN_ARGUMENT))
+      (amountDefault (unwrap! (get-uint-value-by-name jobId "amountDefault") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (as-contract (try! (contract-call? targetToken update-coinbase-amounts amountBonus amount1 amount2 amount3 amount4 amount5 amountDefault)))
+    (as-contract (try! (contract-call? targetCore update-coinbase-amounts)))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; APPROVERS MANAGEMENT
+
+(define-public (execute-replace-approver-job (jobId uint))
+  (let
+    (
+      (oldApprover (unwrap! (get-principal-value-by-name jobId "oldApprover") ERR_UNKNOWN_ARGUMENT))
+      (newApprover (unwrap! (get-principal-value-by-name jobId "newApprover") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (map-set Approvers oldApprover false)
+    (map-set Approvers newApprover true)
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; CONTRACT INITIALIZATION
+
+(map-insert Approvers 'ST3AY0CM7SD9183QZ4Y7S2RGBZX9GQT54MJ6XY0BN true)
+(map-insert Approvers 'ST2D06VFWWTNCWHVB2FJ9KJ3EB30HFRTHB1A4BSP3 true)
+(map-insert Approvers 'ST113N3MMPZRMJJRZH6JTHA5CB7TBZH1EH4C22GFV true)
+(map-insert Approvers 'ST8YRW1THF2XT8E45XXCGYKZH2B70HYH71VC7737 true)
+(map-insert Approvers 'STX13Q7ZJDSFVDZMQ1PWDFGT4QSBMASRMCYE4NAP true)

--- a/contracts/legacy/newyorkcitycoin-auth-v2.clar
+++ b/contracts/legacy/newyorkcitycoin-auth-v2.clar
@@ -5,8 +5,8 @@
 
 ;; TRAIT DEFINITIONS
 
-(use-trait coreTraitV2 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-core-v2-trait.citycoin-core-v2)
-(use-trait tokenTraitV2 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-token-v2-trait.citycoin-token-v2)
+(use-trait coreTraitV2 .citycoin-core-v2-trait.citycoin-core-v2)
+(use-trait tokenTraitV2 .citycoin-token-v2-trait.citycoin-token-v2)
 
 ;; ERRORS
 

--- a/contracts/legacy/newyorkcitycoin-core-v2.clar
+++ b/contracts/legacy/newyorkcitycoin-core-v2.clar
@@ -1,0 +1,1007 @@
+;; NEWYORKCITYCOIN CORE CONTRACT V2 TESTNET
+;; CityCoins Protocol Version 2.0.0
+
+;; GENERAL CONFIGURATION
+
+(impl-trait 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-core-v2-trait.citycoin-core-v2)
+(define-constant CONTRACT_OWNER tx-sender)
+
+;; ERROR CODES
+
+(define-constant ERR_UNAUTHORIZED (err u1000))
+(define-constant ERR_USER_ALREADY_REGISTERED (err u1001))
+(define-constant ERR_USER_NOT_FOUND (err u1002))
+(define-constant ERR_USER_ID_NOT_FOUND (err u1003))
+(define-constant ERR_ACTIVATION_THRESHOLD_REACHED (err u1004))
+(define-constant ERR_CONTRACT_NOT_ACTIVATED (err u1005))
+(define-constant ERR_USER_ALREADY_MINED (err u1006))
+(define-constant ERR_INSUFFICIENT_COMMITMENT (err u1007))
+(define-constant ERR_INSUFFICIENT_BALANCE (err u1008))
+(define-constant ERR_USER_DID_NOT_MINE_IN_BLOCK (err u1009))
+(define-constant ERR_CLAIMED_BEFORE_MATURITY (err u1010))
+(define-constant ERR_NO_MINERS_AT_BLOCK (err u1011))
+(define-constant ERR_REWARD_ALREADY_CLAIMED (err u1012))
+(define-constant ERR_MINER_DID_NOT_WIN (err u1013))
+(define-constant ERR_NO_VRF_SEED_FOUND (err u1014))
+(define-constant ERR_STACKING_NOT_AVAILABLE (err u1015))
+(define-constant ERR_CANNOT_STACK (err u1016))
+(define-constant ERR_REWARD_CYCLE_NOT_COMPLETED (err u1017))
+(define-constant ERR_NOTHING_TO_REDEEM (err u1018))
+(define-constant ERR_UNABLE_TO_FIND_CITY_WALLET (err u1019))
+(define-constant ERR_CLAIM_IN_WRONG_CONTRACT (err u1020))
+(define-constant ERR_BLOCK_HEIGHT_IN_PAST (err u1021))
+(define-constant ERR_COINBASE_AMOUNTS_NOT_FOUND (err u1022))
+
+;; CITY WALLET MANAGEMENT
+
+;; initial value for city wallet, set to this contract until initialized
+(define-data-var cityWallet principal 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-core-v2)
+
+;; returns set city wallet principal
+(define-read-only (get-city-wallet)
+  (var-get cityWallet)
+)
+ 
+;; protected function to update city wallet variable
+(define-public (set-city-wallet (newCityWallet principal))
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (ok (var-set cityWallet newCityWallet))
+  )
+)
+
+;; REGISTRATION
+
+(define-constant NEWYORKCITYCOIN_ACTIVATION_HEIGHT u37449)
+(define-data-var activationBlock uint u340282366920938463463374607431768211455)
+(define-data-var activationDelay uint u1) ;; TESTNET: set to 1 block
+(define-data-var activationReached bool false)
+(define-data-var activationTarget uint u0)
+(define-data-var activationThreshold uint u2) ;; TESTNET: set to 2 users
+(define-data-var usersNonce uint u0)
+
+;; returns Stacks block height registration was activated at plus activationDelay
+(define-read-only (get-activation-block)
+  (begin
+    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (ok (var-get activationBlock))
+  )
+)
+
+;; returns activation delay
+(define-read-only (get-activation-delay)
+  (var-get activationDelay)
+)
+
+;; returns activation status as boolean
+(define-read-only (get-activation-status)
+  (var-get activationReached)
+)
+
+;; returns activation target
+(define-read-only (get-activation-target)
+  (begin
+    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (ok (var-get activationTarget))
+  )
+)
+
+;; returns activation threshold
+(define-read-only (get-activation-threshold)
+  (var-get activationThreshold)
+)
+
+;; returns number of registered users, used for activation and tracking user IDs
+(define-read-only (get-registered-users-nonce)
+  (var-get usersNonce)
+)
+
+;; store user principal by user id
+(define-map Users
+  uint
+  principal
+)
+
+;; store user id by user principal
+(define-map UserIds
+  principal
+  uint
+)
+
+;; returns (some userId) or none
+(define-read-only (get-user-id (user principal))
+  (map-get? UserIds user)
+)
+
+;; returns (some userPrincipal) or none
+(define-read-only (get-user (userId uint))
+  (map-get? Users userId)
+)
+
+;; returns user ID if it has been created, or creates and returns new ID
+(define-private (get-or-create-user-id (user principal))
+  (match
+    (map-get? UserIds user)
+    value value
+    (let
+      (
+        (newId (+ u1 (var-get usersNonce)))
+      )
+      (map-set Users newId user)
+      (map-set UserIds user newId)
+      (var-set usersNonce newId)
+      newId
+    )
+  )
+)
+
+;; registers users that signal activation of contract until threshold is met
+(define-public (register-user (memo (optional (string-utf8 50))))
+  (let
+    (
+      (newId (+ u1 (var-get usersNonce)))
+      (threshold (var-get activationThreshold))
+      (initialized (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2 is-initialized))
+    )
+
+    (asserts! initialized ERR_UNAUTHORIZED)
+
+    (asserts! (is-none (map-get? UserIds tx-sender))
+      ERR_USER_ALREADY_REGISTERED)
+
+    (asserts! (<= newId threshold)
+      ERR_ACTIVATION_THRESHOLD_REACHED)
+
+    (if (is-some memo)
+      (print memo)
+      none
+    )
+
+    (get-or-create-user-id tx-sender)
+
+    (if (is-eq newId threshold)
+      (let
+        (
+          (activationTargetBlock (+ block-height (var-get activationDelay)))
+        )
+        (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2 activate-core-contract (as-contract tx-sender) activationTargetBlock))
+        (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 activate-token (as-contract tx-sender) NEWYORKCITYCOIN_ACTIVATION_HEIGHT))
+        (try! (set-coinbase-thresholds))
+        (try! (set-coinbase-amounts))
+        (var-set activationReached true)
+        (var-set activationBlock NEWYORKCITYCOIN_ACTIVATION_HEIGHT)
+        (var-set activationTarget activationTargetBlock)
+        (ok true)
+      )
+      (ok true)
+    )
+  )
+)
+
+;; MINING CONFIGURATION
+
+;; define split to custodied wallet address for the city
+(define-constant SPLIT_CITY_PCT u30)
+
+;; how long a miner must wait before block winner can claim their minted tokens
+(define-data-var tokenRewardMaturity uint u10) ;; TESTNET: set to 10 blocks
+
+;; At a given Stacks block height:
+;; - how many miners were there
+;; - what was the total amount submitted
+;; - what was the total amount submitted to the city
+;; - what was the total amount submitted to Stackers
+;; - was the block reward claimed
+(define-map MiningStatsAtBlock
+  uint
+  {
+    minersCount: uint,
+    amount: uint,
+    amountToCity: uint,
+    amountToStackers: uint,
+    rewardClaimed: bool
+  }
+)
+
+;; returns map MiningStatsAtBlock at a given Stacks block height if it exists
+(define-read-only (get-mining-stats-at-block (stacksHeight uint))
+  (map-get? MiningStatsAtBlock stacksHeight)
+)
+
+;; returns map MiningStatsAtBlock at a given Stacks block height
+;; or, an empty structure
+(define-read-only (get-mining-stats-at-block-or-default (stacksHeight uint))
+  (default-to {
+      minersCount: u0,
+      amount: u0,
+      amountToCity: u0,
+      amountToStackers: u0,
+      rewardClaimed: false
+    }
+    (map-get? MiningStatsAtBlock stacksHeight)
+  )
+)
+
+;; At a given Stacks block height and user ID:
+;; - what is their ustx commitment
+;; - what are the low/high values (used for VRF)
+(define-map MinersAtBlock
+  {
+    stacksHeight: uint,
+    userId: uint
+  }
+  {
+    ustx: uint,
+    lowValue: uint,
+    highValue: uint,
+    winner: bool
+  }
+)
+
+;; returns true if a given miner has already mined at a given block height
+(define-read-only (has-mined-at-block (stacksHeight uint) (userId uint))
+  (is-some 
+    (map-get? MinersAtBlock { stacksHeight: stacksHeight, userId: userId })
+  )
+)
+
+;; returns map MinersAtBlock at a given Stacks block height for a user ID
+(define-read-only (get-miner-at-block (stacksHeight uint) (userId uint))
+  (map-get? MinersAtBlock { stacksHeight: stacksHeight, userId: userId })
+)
+
+;; returns map MinersAtBlock at a given Stacks block height for a user ID
+;; or, an empty structure
+(define-read-only (get-miner-at-block-or-default (stacksHeight uint) (userId uint))
+  (default-to {
+    highValue: u0,
+    lowValue: u0,
+    ustx: u0,
+    winner: false
+  }
+    (map-get? MinersAtBlock { stacksHeight: stacksHeight, userId: userId }))
+)
+
+;; At a given Stacks block height:
+;; - what is the max highValue from MinersAtBlock (used for VRF)
+(define-map MinersAtBlockHighValue
+  uint
+  uint
+)
+
+;; returns last high value from map MinersAtBlockHighValue
+(define-read-only (get-last-high-value-at-block (stacksHeight uint))
+  (default-to u0
+    (map-get? MinersAtBlockHighValue stacksHeight))
+)
+
+;; At a given Stacks block height:
+;; - what is the userId of miner who won this block
+(define-map BlockWinnerIds
+  uint
+  uint
+)
+
+(define-read-only (get-block-winner-id (stacksHeight uint))
+  (map-get? BlockWinnerIds stacksHeight)
+)
+
+;; MINING ACTIONS
+
+(define-public (mine-tokens (amountUstx uint) (memo (optional (buff 34))))
+  (let
+    (
+      (userId (get-or-create-user-id tx-sender))
+    )
+    (try! (mine-tokens-at-block userId block-height amountUstx memo))
+    (ok true)
+  )
+)
+
+(define-public (mine-many (amounts (list 200 uint)))
+  (begin
+    (asserts! (is-activated) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (> (len amounts) u0) ERR_INSUFFICIENT_COMMITMENT)
+    (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
+      okReturn 
+      (begin
+        (asserts! (>= (stx-get-balance tx-sender) (+ (get toStackers okReturn) (get toCity okReturn))) ERR_INSUFFICIENT_BALANCE)
+        (if (> (get toStackers okReturn ) u0)
+          (try! (stx-transfer? (get toStackers okReturn ) tx-sender (as-contract tx-sender)))
+          false
+        )
+        (try! (stx-transfer? (get toCity okReturn) tx-sender (var-get cityWallet)))
+        (print { 
+          firstBlock: block-height, 
+          lastBlock: (- (+ block-height (len amounts)) u1) 
+        })
+        (ok true)
+      )
+      errReturn (err errReturn)
+    )
+  )
+)
+
+(define-private (mine-single 
+  (amountUstx uint) 
+  (return (response 
+    { 
+      userId: uint,
+      toStackers: uint,
+      toCity: uint,
+      stacksHeight: uint
+    }
+    uint
+  )))
+
+  (match return okReturn
+    (let
+      (
+        (stacksHeight (get stacksHeight okReturn))
+        (rewardCycle (default-to u0 (get-reward-cycle stacksHeight)))
+        (stackingActive (stacking-active-at-cycle rewardCycle))
+        (toCity
+          (if stackingActive
+            (/ (* SPLIT_CITY_PCT amountUstx) u100)
+            amountUstx
+          )
+        )
+        (toStackers (- amountUstx toCity))
+      )
+      (asserts! (not (has-mined-at-block stacksHeight (get userId okReturn))) ERR_USER_ALREADY_MINED)
+      (asserts! (> amountUstx u0) ERR_INSUFFICIENT_COMMITMENT)
+      (try! (set-tokens-mined (get userId okReturn) stacksHeight amountUstx toStackers toCity))
+      (ok (merge okReturn 
+        {
+          toStackers: (+ (get toStackers okReturn) toStackers),
+          toCity: (+ (get toCity okReturn) toCity),
+          stacksHeight: (+ stacksHeight u1)
+        }
+      ))
+    )
+    errReturn (err errReturn)
+  ) 
+)
+
+(define-private (mine-tokens-at-block (userId uint) (stacksHeight uint) (amountUstx uint) (memo (optional (buff 34))))
+  (let
+    (
+      (rewardCycle (default-to u0 (get-reward-cycle stacksHeight)))
+      (stackingActive (stacking-active-at-cycle rewardCycle))
+      (toCity
+        (if stackingActive
+          (/ (* SPLIT_CITY_PCT amountUstx) u100)
+          amountUstx
+        )
+      )
+      (toStackers (- amountUstx toCity))
+    )
+    (asserts! (is-activated) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (not (has-mined-at-block stacksHeight userId)) ERR_USER_ALREADY_MINED)
+    (asserts! (> amountUstx u0) ERR_INSUFFICIENT_COMMITMENT)
+    (asserts! (>= (stx-get-balance tx-sender) amountUstx) ERR_INSUFFICIENT_BALANCE)
+    (try! (set-tokens-mined userId stacksHeight amountUstx toStackers toCity))
+    (if (is-some memo)
+      (print memo)
+      none
+    )
+    (if stackingActive
+      (try! (stx-transfer? toStackers tx-sender (as-contract tx-sender)))
+      false
+    )
+    (try! (stx-transfer? toCity tx-sender (var-get cityWallet)))
+    (ok true)
+  )
+)
+
+(define-private (set-tokens-mined (userId uint) (stacksHeight uint) (amountUstx uint) (toStackers uint) (toCity uint))
+  (let
+    (
+      (blockStats (get-mining-stats-at-block-or-default stacksHeight))
+      (newMinersCount (+ (get minersCount blockStats) u1))
+      (minerLowVal (get-last-high-value-at-block stacksHeight))
+      (rewardCycle (unwrap! (get-reward-cycle stacksHeight)
+        ERR_STACKING_NOT_AVAILABLE))
+      (rewardCycleStats (get-stacking-stats-at-cycle-or-default rewardCycle))
+    )
+    (map-set MiningStatsAtBlock
+      stacksHeight
+      {
+        minersCount: newMinersCount,
+        amount: (+ (get amount blockStats) amountUstx),
+        amountToCity: (+ (get amountToCity blockStats) toCity),
+        amountToStackers: (+ (get amountToStackers blockStats) toStackers),
+        rewardClaimed: false
+      }
+    )
+    (map-set MinersAtBlock
+      {
+        stacksHeight: stacksHeight,
+        userId: userId
+      }
+      {
+        ustx: amountUstx,
+        lowValue: (if (> minerLowVal u0) (+ minerLowVal u1) u0),
+        highValue: (+ minerLowVal amountUstx),
+        winner: false
+      }
+    )
+    (map-set MinersAtBlockHighValue
+      stacksHeight
+      (+ minerLowVal amountUstx)
+    )
+    (if (> toStackers u0)
+      (map-set StackingStatsAtCycle
+        rewardCycle
+        {
+          amountUstx: (+ (get amountUstx rewardCycleStats) toStackers),
+          amountToken: (get amountToken rewardCycleStats)
+        }
+      )
+      false
+    )
+    (ok true)
+  )
+)
+
+;; MINING REWARD CLAIM ACTIONS
+
+;; calls function to claim mining reward in active logic contract
+(define-public (claim-mining-reward (minerBlockHeight uint))
+  (begin
+    (asserts! (or (is-eq (var-get shutdownHeight) u0) (< minerBlockHeight (var-get shutdownHeight))) ERR_CLAIM_IN_WRONG_CONTRACT)
+    (try! (claim-mining-reward-at-block tx-sender block-height minerBlockHeight))
+    (ok true)
+  )
+)
+
+;; Determine whether or not the given principal can claim the mined tokens at a particular block height,
+;; given the miners record for that block height, a random sample, and the current block height.
+(define-private (claim-mining-reward-at-block (user principal) (stacksHeight uint) (minerBlockHeight uint))
+  (let
+    (
+      (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
+      (userId (unwrap! (get-user-id user) ERR_USER_ID_NOT_FOUND))
+      (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) ERR_NO_MINERS_AT_BLOCK))
+      (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) ERR_USER_DID_NOT_MINE_IN_BLOCK))
+      (isMature (asserts! (> stacksHeight maturityHeight) ERR_CLAIMED_BEFORE_MATURITY))
+      (vrfSample (unwrap! (contract-call? 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-vrf-v2 get-save-rnd maturityHeight) ERR_NO_VRF_SEED_FOUND))
+      (commitTotal (get-last-high-value-at-block minerBlockHeight))
+      (winningValue (mod vrfSample commitTotal))
+    )
+    (asserts! (not (get rewardClaimed blockStats)) ERR_REWARD_ALREADY_CLAIMED)
+    (asserts! (and (>= winningValue (get lowValue minerStats)) (<= winningValue (get highValue minerStats)))
+      ERR_MINER_DID_NOT_WIN)
+    (try! (set-mining-reward-claimed userId minerBlockHeight))
+    (ok true)
+  )
+)
+
+(define-private (set-mining-reward-claimed (userId uint) (minerBlockHeight uint))
+  (let
+    (
+      (blockStats (get-mining-stats-at-block-or-default minerBlockHeight))
+      (minerStats (get-miner-at-block-or-default minerBlockHeight userId))
+      (user (unwrap! (get-user userId) ERR_USER_NOT_FOUND))
+    )
+    (map-set MiningStatsAtBlock
+      minerBlockHeight
+      {
+        minersCount: (get minersCount blockStats),
+        amount: (get amount blockStats),
+        amountToCity: (get amountToCity blockStats),
+        amountToStackers: (get amountToStackers blockStats),
+        rewardClaimed: true
+      }
+    )
+    (map-set MinersAtBlock
+      {
+        stacksHeight: minerBlockHeight,
+        userId: userId
+      }
+      {
+        ustx: (get ustx minerStats),
+        lowValue: (get lowValue minerStats),
+        highValue: (get highValue minerStats),
+        winner: true
+      }
+    )
+    (map-set BlockWinnerIds
+      minerBlockHeight
+      userId
+    )
+    (try! (mint-coinbase user minerBlockHeight))
+    (ok true)
+  )
+)
+
+(define-read-only (is-block-winner (user principal) (minerBlockHeight uint))
+  (is-block-winner-and-can-claim user minerBlockHeight false)
+)
+
+(define-read-only (can-claim-mining-reward (user principal) (minerBlockHeight uint))
+  (is-block-winner-and-can-claim user minerBlockHeight true)
+)
+
+(define-private (is-block-winner-and-can-claim (user principal) (minerBlockHeight uint) (testCanClaim bool))
+  (let
+    (
+      (userId (unwrap! (get-user-id user) false))
+      (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) false))
+      (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) false))
+      (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
+      (vrfSample (unwrap! (contract-call? 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-vrf-v2 get-rnd maturityHeight) false))
+      (commitTotal (get-last-high-value-at-block minerBlockHeight))
+      (winningValue (mod vrfSample commitTotal))
+    )
+    (if (and (>= winningValue (get lowValue minerStats)) (<= winningValue (get highValue minerStats)))
+      (if testCanClaim (not (get rewardClaimed blockStats)) true)
+      false
+    )
+  )
+)
+
+;; STACKING CONFIGURATION
+
+(define-constant MAX_REWARD_CYCLES u32)
+(define-constant REWARD_CYCLE_INDEXES (list u0 u1 u2 u3 u4 u5 u6 u7 u8 u9 u10 u11 u12 u13 u14 u15 u16 u17 u18 u19 u20 u21 u22 u23 u24 u25 u26 u27 u28 u29 u30 u31))
+
+;; how long a reward cycle is
+(define-data-var rewardCycleLength uint u20) ;; TESTNET: set to 20 blocks
+
+;; At a given reward cycle:
+;; - how many Stackers were there
+;; - what is the total uSTX submitted by miners
+;; - what is the total amount of tokens stacked
+(define-map StackingStatsAtCycle
+  uint
+  {
+    amountUstx: uint,
+    amountToken: uint
+  }
+)
+
+;; returns the total stacked tokens and committed uSTX for a given reward cycle
+(define-read-only (get-stacking-stats-at-cycle (rewardCycle uint))
+  (map-get? StackingStatsAtCycle rewardCycle)
+)
+
+;; returns the total stacked tokens and committed uSTX for a given reward cycle
+;; or, an empty structure
+(define-read-only (get-stacking-stats-at-cycle-or-default (rewardCycle uint))
+  (default-to { amountUstx: u0, amountToken: u0 }
+    (map-get? StackingStatsAtCycle rewardCycle))
+)
+
+;; At a given reward cycle and user ID:
+;; - what is the total tokens Stacked?
+;; - how many tokens should be returned? (based on Stacking period)
+(define-map StackerAtCycle
+  {
+    rewardCycle: uint,
+    userId: uint
+  }
+  {
+    amountStacked: uint,
+    toReturn: uint
+  }
+)
+
+(define-read-only (get-stacker-at-cycle (rewardCycle uint) (userId uint))
+  (map-get? StackerAtCycle { rewardCycle: rewardCycle, userId: userId })
+)
+
+(define-read-only (get-stacker-at-cycle-or-default (rewardCycle uint) (userId uint))
+  (default-to { amountStacked: u0, toReturn: u0 }
+    (map-get? StackerAtCycle { rewardCycle: rewardCycle, userId: userId }))
+)
+
+;; get the reward cycle for a given Stacks block height
+(define-read-only (get-reward-cycle (stacksHeight uint))
+  (let
+    (
+      (firstStackingBlock (var-get activationBlock))
+      (rcLen (var-get rewardCycleLength))
+    )
+    (if (>= stacksHeight firstStackingBlock)
+      (some (/ (- stacksHeight firstStackingBlock) rcLen))
+      none)
+  )
+)
+
+;; determine if stacking is active in a given cycle
+(define-read-only (stacking-active-at-cycle (rewardCycle uint))
+  (is-some
+    (get amountToken (map-get? StackingStatsAtCycle rewardCycle))
+  )
+)
+
+;; get the first Stacks block height for a given reward cycle.
+(define-read-only (get-first-stacks-block-in-reward-cycle (rewardCycle uint))
+  (+ (var-get activationBlock) (* (var-get rewardCycleLength) rewardCycle))
+)
+
+;; getter for get-entitled-stacking-reward that specifies block height
+(define-read-only (get-stacking-reward (userId uint) (targetCycle uint))
+  (get-entitled-stacking-reward userId targetCycle block-height)
+)
+
+;; get uSTX a Stacker can claim, given reward cycle they stacked in and current block height
+;; this method only returns a positive value if:
+;; - the current block height is in a subsequent reward cycle
+;; - the stacker actually locked up tokens in the target reward cycle
+;; - the stacker locked up _enough_ tokens to get at least one uSTX
+;; it is possible to Stack tokens and not receive uSTX:
+;; - if no miners commit during this reward cycle
+;; - the amount stacked by user is too few that you'd be entitled to less than 1 uSTX
+(define-private (get-entitled-stacking-reward (userId uint) (targetCycle uint) (stacksHeight uint))
+  (let
+    (
+      (rewardCycleStats (get-stacking-stats-at-cycle-or-default targetCycle))
+      (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle userId))
+      (totalUstxThisCycle (get amountUstx rewardCycleStats))
+      (totalStackedThisCycle (get amountToken rewardCycleStats))
+      (userStackedThisCycle (get amountStacked stackerAtCycle))
+    )
+    (match (get-reward-cycle stacksHeight)
+      currentCycle
+      (if (and (not (var-get isShutdown)) 
+        (or (<= currentCycle targetCycle) (is-eq u0 userStackedThisCycle)))
+        ;; the contract is not shut down and
+        ;; this cycle hasn't finished
+        ;; or stacker contributed nothing
+        u0
+        ;; (totalUstxThisCycle * userStackedThisCycle) / totalStackedThisCycle
+        (/ (* totalUstxThisCycle userStackedThisCycle) totalStackedThisCycle)
+      )
+      ;; before first reward cycle
+      u0
+    )
+  )
+)
+
+;; STACKING ACTIONS
+
+(define-public (stack-tokens (amountTokens uint) (lockPeriod uint))
+  (let
+    (
+      (userId (get-or-create-user-id tx-sender))
+    )
+    (try! (stack-tokens-at-cycle tx-sender userId amountTokens block-height lockPeriod))
+    (ok true)
+  )
+)
+
+(define-private (stack-tokens-at-cycle (user principal) (userId uint) (amountTokens uint) (startHeight uint) (lockPeriod uint))
+  (let
+    (
+      (currentCycle (unwrap! (get-reward-cycle startHeight) ERR_STACKING_NOT_AVAILABLE))
+      (targetCycle (+ u1 currentCycle))
+      (commitment {
+        stackerId: userId,
+        amount: amountTokens,
+        first: targetCycle,
+        last: (+ targetCycle lockPeriod)
+      })
+    )
+    (asserts! (is-activated) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (and (> lockPeriod u0) (<= lockPeriod MAX_REWARD_CYCLES))
+      ERR_CANNOT_STACK)
+    (asserts! (> amountTokens u0) ERR_CANNOT_STACK)
+    (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 transfer amountTokens tx-sender (as-contract tx-sender) none))
+    (print {
+      firstCycle: targetCycle, 
+      lastCycle: (- (+ targetCycle lockPeriod) u1)
+    })
+    (match (fold stack-tokens-closure REWARD_CYCLE_INDEXES (ok commitment))
+      okValue (ok true)
+      errValue (err errValue)
+    )
+  )
+)
+
+(define-private (stack-tokens-closure (rewardCycleIdx uint)
+  (commitmentResponse (response 
+    {
+      stackerId: uint,
+      amount: uint,
+      first: uint,
+      last: uint
+    }
+    uint
+  )))
+
+  (match commitmentResponse
+    commitment 
+    (let
+      (
+        (stackerId (get stackerId commitment))
+        (amountToken (get amount commitment))
+        (firstCycle (get first commitment))
+        (lastCycle (get last commitment))
+        (targetCycle (+ firstCycle rewardCycleIdx))
+      )
+      (begin
+        (if (and (>= targetCycle firstCycle) (< targetCycle lastCycle))
+          (begin
+            (if (is-eq targetCycle (- lastCycle u1))
+              (set-tokens-stacked stackerId targetCycle amountToken amountToken)
+              (set-tokens-stacked stackerId targetCycle amountToken u0)
+            )
+            true
+          )
+          false
+        )
+        commitmentResponse
+      )
+    )
+    errValue commitmentResponse
+  )
+)
+
+(define-private (set-tokens-stacked (userId uint) (targetCycle uint) (amountStacked uint) (toReturn uint))
+  (let
+    (
+      (rewardCycleStats (get-stacking-stats-at-cycle-or-default targetCycle))
+      (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle userId))
+    )
+    (map-set StackingStatsAtCycle
+      targetCycle
+      {
+        amountUstx: (get amountUstx rewardCycleStats),
+        amountToken: (+ amountStacked (get amountToken rewardCycleStats))
+      }
+    )
+    (map-set StackerAtCycle
+      {
+        rewardCycle: targetCycle,
+        userId: userId
+      }
+      {
+        amountStacked: (+ amountStacked (get amountStacked stackerAtCycle)),
+        toReturn: (+ toReturn (get toReturn stackerAtCycle))
+      }
+    )
+  )
+)
+
+;; STACKING REWARD CLAIMS
+
+;; calls function to claim stacking reward in active logic contract
+(define-public (claim-stacking-reward (targetCycle uint))
+  (begin
+    (try! (claim-stacking-reward-at-cycle tx-sender block-height targetCycle))
+    (ok true)
+  )
+)
+
+(define-private (claim-stacking-reward-at-cycle (user principal) (stacksHeight uint) (targetCycle uint))
+  (let
+    (
+      (currentCycle (unwrap! (get-reward-cycle stacksHeight) ERR_STACKING_NOT_AVAILABLE))
+      (userId (unwrap! (get-user-id user) ERR_USER_ID_NOT_FOUND))
+      (entitledUstx (get-entitled-stacking-reward userId targetCycle stacksHeight))
+      (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle userId))
+      (toReturn (get toReturn stackerAtCycle))
+    )
+    (asserts! (or
+      (is-eq true (var-get isShutdown))
+      (> currentCycle targetCycle))
+      ERR_REWARD_CYCLE_NOT_COMPLETED)
+    (asserts! (or (> toReturn u0) (> entitledUstx u0)) ERR_NOTHING_TO_REDEEM)
+    ;; disable ability to claim again
+    (map-set StackerAtCycle
+      {
+        rewardCycle: targetCycle,
+        userId: userId
+      }
+      {
+        amountStacked: u0,
+        toReturn: u0
+      }
+    )
+    ;; send back tokens if user was eligible
+    (if (> toReturn u0)
+      (try! (as-contract (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 transfer toReturn tx-sender user none)))
+      true
+    )
+    ;; send back rewards if user was eligible
+    (if (> entitledUstx u0)
+      (try! (as-contract (stx-transfer? entitledUstx tx-sender user)))
+      true
+    )
+    (ok true)
+  )
+)
+
+;; TOKEN CONFIGURATION
+
+;; decimals and multiplier for token
+(define-constant DECIMALS u6)
+(define-constant MICRO_CITYCOINS (pow u10 DECIMALS))
+
+;; bonus period length for increased coinbase rewards
+(define-constant TOKEN_BONUS_PERIOD u10000)
+
+;; coinbase thresholds per halving, used to determine halvings
+(define-data-var coinbaseThreshold1 uint u0)
+(define-data-var coinbaseThreshold2 uint u0)
+(define-data-var coinbaseThreshold3 uint u0)
+(define-data-var coinbaseThreshold4 uint u0)
+(define-data-var coinbaseThreshold5 uint u0)
+
+;; return coinbase thresholds if contract activated
+(define-read-only (get-coinbase-thresholds)
+  (let
+    (
+      (activated (get-activation-status))
+    )
+    (asserts! activated ERR_CONTRACT_NOT_ACTIVATED)
+    (ok {
+      coinbaseThreshold1: (var-get coinbaseThreshold1),
+      coinbaseThreshold2: (var-get coinbaseThreshold2),
+      coinbaseThreshold3: (var-get coinbaseThreshold3),
+      coinbaseThreshold4: (var-get coinbaseThreshold4),
+      coinbaseThreshold5: (var-get coinbaseThreshold5)
+    })
+  )
+)
+
+;; set coinbase thresholds, used during activation
+(define-private (set-coinbase-thresholds)
+  (let
+    (
+      (coinbaseThresholds (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 get-coinbase-thresholds)))
+    )
+    (var-set coinbaseThreshold1 (get coinbaseThreshold1 coinbaseThresholds))
+    (var-set coinbaseThreshold2 (get coinbaseThreshold2 coinbaseThresholds))
+    (var-set coinbaseThreshold3 (get coinbaseThreshold3 coinbaseThresholds))
+    (var-set coinbaseThreshold4 (get coinbaseThreshold4 coinbaseThresholds))
+    (var-set coinbaseThreshold5 (get coinbaseThreshold5 coinbaseThresholds))
+    ;; print coinbase thresholds
+    (print {
+      coinbaseThreshold1: (var-get coinbaseThreshold1),
+      coinbaseThreshold2: (var-get coinbaseThreshold2),
+      coinbaseThreshold3: (var-get coinbaseThreshold3),
+      coinbaseThreshold4: (var-get coinbaseThreshold4),
+      coinbaseThreshold5: (var-get coinbaseThreshold5)
+    })
+    (ok true)
+  )
+)
+
+;; guarded function for auth to update coinbase thresholds
+(define-public (update-coinbase-thresholds)
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (try! (set-coinbase-thresholds))
+    (ok true)
+  )
+)
+
+;; coinbase rewards per threshold, used to determine rewards
+(define-data-var coinbaseAmountBonus uint u0)
+(define-data-var coinbaseAmount1 uint u0)
+(define-data-var coinbaseAmount2 uint u0)
+(define-data-var coinbaseAmount3 uint u0)
+(define-data-var coinbaseAmount4 uint u0)
+(define-data-var coinbaseAmount5 uint u0)
+(define-data-var coinbaseAmountDefault uint u0)
+
+;; return coinbase amounts if contract activated
+(define-read-only (get-coinbase-amounts)
+  (let
+    (
+      (activated (get-activation-status))
+    )
+    (asserts! activated ERR_CONTRACT_NOT_ACTIVATED)
+    (ok {
+      coinbaseAmountBonus: (var-get coinbaseAmountBonus),
+      coinbaseAmount1: (var-get coinbaseAmount1),
+      coinbaseAmount2: (var-get coinbaseAmount2),
+      coinbaseAmount3: (var-get coinbaseAmount3),
+      coinbaseAmount4: (var-get coinbaseAmount4),
+      coinbaseAmount5: (var-get coinbaseAmount5),
+      coinbaseAmountDefault: (var-get coinbaseAmountDefault)
+    })
+  )
+)
+
+;; set coinbase amounts, used during activation
+(define-private (set-coinbase-amounts)
+  (let
+    (
+      (coinbaseAmounts (unwrap! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 get-coinbase-amounts) ERR_COINBASE_AMOUNTS_NOT_FOUND))
+    )
+    (var-set coinbaseAmountBonus (get coinbaseAmountBonus coinbaseAmounts))
+    (var-set coinbaseAmount1 (get coinbaseAmount1 coinbaseAmounts))
+    (var-set coinbaseAmount2 (get coinbaseAmount2 coinbaseAmounts))
+    (var-set coinbaseAmount3 (get coinbaseAmount3 coinbaseAmounts))
+    (var-set coinbaseAmount4 (get coinbaseAmount4 coinbaseAmounts))
+    (var-set coinbaseAmount5 (get coinbaseAmount5 coinbaseAmounts))
+    (var-set coinbaseAmountDefault (get coinbaseAmountDefault coinbaseAmounts))
+    ;; print coinbase amounts
+    (print {
+      coinbaseAmountBonus: (var-get coinbaseAmountBonus),
+      coinbaseAmount1: (var-get coinbaseAmount1),
+      coinbaseAmount2: (var-get coinbaseAmount2),
+      coinbaseAmount3: (var-get coinbaseAmount3),
+      coinbaseAmount4: (var-get coinbaseAmount4),
+      coinbaseAmount5: (var-get coinbaseAmount5),
+      coinbaseAmountDefault: (var-get coinbaseAmountDefault)
+    })
+    (ok true)
+  )
+)
+
+;; guarded function for auth to update coinbase amounts
+(define-public (update-coinbase-amounts)
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (try! (set-coinbase-amounts))
+    (ok true)
+  )
+)
+
+;; function for deciding how many tokens to mint, depending on when they were mined
+(define-read-only (get-coinbase-amount (minerBlockHeight uint))
+  (begin
+    ;; if contract is not active, return 0
+    (asserts! (>= minerBlockHeight (var-get activationBlock)) u0)
+    ;; if contract is active, return based on emissions schedule
+    ;; defined in CCIP-008 https://github.com/citycoins/governance
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold1))
+      (if (<= (- minerBlockHeight (var-get activationBlock)) TOKEN_BONUS_PERIOD)
+        ;; bonus reward for initial miners
+        (var-get coinbaseAmountBonus)
+        ;; standard reward until 1st halving
+        (var-get coinbaseAmount1)
+      )
+    )
+    ;; computations based on each halving threshold
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold2)) (var-get coinbaseAmount2))
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold3)) (var-get coinbaseAmount3))
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold4)) (var-get coinbaseAmount4))
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold5)) (var-get coinbaseAmount5))
+    ;; default value after 5th halving
+    (var-get coinbaseAmountDefault)
+  )
+)
+
+;; mint new tokens for claimant who won at given Stacks block height
+(define-private (mint-coinbase (recipient principal) (stacksHeight uint))
+  (as-contract (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 mint (get-coinbase-amount stacksHeight) recipient))
+)
+
+;; UTILITIES
+
+(define-data-var shutdownHeight uint u0)
+(define-data-var isShutdown bool false)
+
+;; stop mining and stacking operations
+;; in preparation for a core upgrade
+(define-public (shutdown-contract (stacksHeight uint))
+  (begin
+    ;; make sure block height is in the future
+    (asserts! (>= stacksHeight block-height) ERR_BLOCK_HEIGHT_IN_PAST)
+    ;; only allow shutdown request from AUTH
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    ;; set variables to disable mining/stacking in CORE
+    (var-set activationReached false)
+    (var-set shutdownHeight stacksHeight)
+    ;; set variable to allow for all stacking claims
+    (var-set isShutdown true)
+    (ok true)
+  )
+)
+
+;; checks if caller is Auth contract
+(define-private (is-authorized-auth)
+  (is-eq contract-caller 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2)
+)
+
+;; checks if contract is fully activated to
+;; enable mining and stacking functions
+(define-private (is-activated)
+  (and (get-activation-status) (>= block-height (var-get activationTarget)))
+)

--- a/contracts/legacy/newyorkcitycoin-core-v2.clar
+++ b/contracts/legacy/newyorkcitycoin-core-v2.clar
@@ -35,7 +35,7 @@
 ;; CITY WALLET MANAGEMENT
 
 ;; initial value for city wallet, set to this contract until initialized
-(define-data-var cityWallet principal 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-core-v2)
+(define-data-var cityWallet principal .newyorkcitycoin-core-v2)
 
 ;; returns set city wallet principal
 (define-read-only (get-city-wallet)
@@ -141,7 +141,7 @@
     (
       (newId (+ u1 (var-get usersNonce)))
       (threshold (var-get activationThreshold))
-      (initialized (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2 is-initialized))
+      (initialized (contract-call? .newyorkcitycoin-auth-v2 is-initialized))
     )
 
     (asserts! initialized ERR_UNAUTHORIZED)
@@ -164,8 +164,8 @@
         (
           (activationTargetBlock (+ block-height (var-get activationDelay)))
         )
-        (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2 activate-core-contract (as-contract tx-sender) activationTargetBlock))
-        (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 activate-token (as-contract tx-sender) NEWYORKCITYCOIN_ACTIVATION_HEIGHT))
+        (try! (contract-call? .newyorkcitycoin-auth-v2 activate-core-contract (as-contract tx-sender) activationTargetBlock))
+        (try! (contract-call? .newyorkcitycoin-token-v2 activate-token (as-contract tx-sender) NEWYORKCITYCOIN_ACTIVATION_HEIGHT))
         (try! (set-coinbase-thresholds))
         (try! (set-coinbase-amounts))
         (var-set activationReached true)
@@ -465,7 +465,7 @@
       (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) ERR_NO_MINERS_AT_BLOCK))
       (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) ERR_USER_DID_NOT_MINE_IN_BLOCK))
       (isMature (asserts! (> stacksHeight maturityHeight) ERR_CLAIMED_BEFORE_MATURITY))
-      (vrfSample (unwrap! (contract-call? 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-vrf-v2 get-save-rnd maturityHeight) ERR_NO_VRF_SEED_FOUND))
+      (vrfSample (unwrap! (contract-call? .citycoin-vrf-v2 get-save-rnd maturityHeight) ERR_NO_VRF_SEED_FOUND))
       (commitTotal (get-last-high-value-at-block minerBlockHeight))
       (winningValue (mod vrfSample commitTotal))
     )
@@ -530,7 +530,7 @@
       (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) false))
       (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) false))
       (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
-      (vrfSample (unwrap! (contract-call? 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-vrf-v2 get-rnd maturityHeight) false))
+      (vrfSample (unwrap! (contract-call? .citycoin-vrf-v2 get-rnd maturityHeight) false))
       (commitTotal (get-last-high-value-at-block minerBlockHeight))
       (winningValue (mod vrfSample commitTotal))
     )
@@ -688,7 +688,7 @@
     (asserts! (and (> lockPeriod u0) (<= lockPeriod MAX_REWARD_CYCLES))
       ERR_CANNOT_STACK)
     (asserts! (> amountTokens u0) ERR_CANNOT_STACK)
-    (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 transfer amountTokens tx-sender (as-contract tx-sender) none))
+    (try! (contract-call? .newyorkcitycoin-token-v2 transfer amountTokens tx-sender (as-contract tx-sender) none))
     (print {
       firstCycle: targetCycle, 
       lastCycle: (- (+ targetCycle lockPeriod) u1)
@@ -802,7 +802,7 @@
     )
     ;; send back tokens if user was eligible
     (if (> toReturn u0)
-      (try! (as-contract (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 transfer toReturn tx-sender user none)))
+      (try! (as-contract (contract-call? .newyorkcitycoin-token-v2 transfer toReturn tx-sender user none)))
       true
     )
     ;; send back rewards if user was eligible
@@ -851,7 +851,7 @@
 (define-private (set-coinbase-thresholds)
   (let
     (
-      (coinbaseThresholds (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 get-coinbase-thresholds)))
+      (coinbaseThresholds (try! (contract-call? .newyorkcitycoin-token-v2 get-coinbase-thresholds)))
     )
     (var-set coinbaseThreshold1 (get coinbaseThreshold1 coinbaseThresholds))
     (var-set coinbaseThreshold2 (get coinbaseThreshold2 coinbaseThresholds))
@@ -911,7 +911,7 @@
 (define-private (set-coinbase-amounts)
   (let
     (
-      (coinbaseAmounts (unwrap! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 get-coinbase-amounts) ERR_COINBASE_AMOUNTS_NOT_FOUND))
+      (coinbaseAmounts (unwrap! (contract-call? .newyorkcitycoin-token-v2 get-coinbase-amounts) ERR_COINBASE_AMOUNTS_NOT_FOUND))
     )
     (var-set coinbaseAmountBonus (get coinbaseAmountBonus coinbaseAmounts))
     (var-set coinbaseAmount1 (get coinbaseAmount1 coinbaseAmounts))
@@ -970,7 +970,7 @@
 
 ;; mint new tokens for claimant who won at given Stacks block height
 (define-private (mint-coinbase (recipient principal) (stacksHeight uint))
-  (as-contract (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-token-v2 mint (get-coinbase-amount stacksHeight) recipient))
+  (as-contract (contract-call? .newyorkcitycoin-token-v2 mint (get-coinbase-amount stacksHeight) recipient))
 )
 
 ;; UTILITIES
@@ -997,7 +997,7 @@
 
 ;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
-  (is-eq contract-caller 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2)
+  (is-eq contract-caller .newyorkcitycoin-auth-v2)
 )
 
 ;; checks if contract is fully activated to

--- a/contracts/legacy/newyorkcitycoin-core-v2.clar
+++ b/contracts/legacy/newyorkcitycoin-core-v2.clar
@@ -3,7 +3,7 @@
 
 ;; GENERAL CONFIGURATION
 
-(impl-trait 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-core-v2-trait.citycoin-core-v2)
+(impl-trait .citycoin-core-v2-trait.citycoin-core-v2)
 (define-constant CONTRACT_OWNER tx-sender)
 
 ;; ERROR CODES

--- a/contracts/legacy/newyorkcitycoin-token-v2.clar
+++ b/contracts/legacy/newyorkcitycoin-token-v2.clar
@@ -1,0 +1,281 @@
+;; NEWYORKCITYCOIN TOKEN V2 CONTRACT TESTNET
+;; CityCoins Protocol Version 2.0.0
+
+;; TRAIT DEFINITIONS
+
+(impl-trait 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-token-v2-trait.citycoin-token-v2)
+
+;; ERROR CODES
+
+(define-constant ERR_UNAUTHORIZED (err u2000))
+(define-constant ERR_TOKEN_NOT_ACTIVATED (err u2001))
+(define-constant ERR_TOKEN_ALREADY_ACTIVATED (err u2002))
+(define-constant ERR_V1_BALANCE_NOT_FOUND (err u2003))
+(define-constant ERR_INVALID_COINBASE_THRESHOLD (err u2004))
+(define-constant ERR_INVALID_COINBASE_AMOUNT (err u2005))
+
+;; SIP-010 DEFINITION
+
+(impl-trait 'ST1NXBK3K5YYMD6FD41MVNP3JS1GABZ8TRVX023PT.sip-010-trait-ft-standard.sip-010-trait)
+
+(define-fungible-token newyorkcitycoin)
+
+(define-constant DECIMALS u6)
+(define-constant MICRO_CITYCOINS (pow u10 DECIMALS))
+
+;; SIP-010 FUNCTIONS
+
+(define-public (transfer (amount uint) (from principal) (to principal) (memo (optional (buff 34))))
+  (begin
+    (asserts! (is-eq from tx-sender) ERR_UNAUTHORIZED)
+    (if (is-some memo)
+      (print memo)
+      none
+    )
+    (ft-transfer? newyorkcitycoin amount from to)
+  )
+)
+
+(define-read-only (get-name)
+  (ok "newyorkcitycoin")
+)
+
+(define-read-only (get-symbol)
+  (ok "NYC")
+)
+
+(define-read-only (get-decimals)
+  (ok DECIMALS)
+)
+
+(define-read-only (get-balance (user principal))
+  (ok (ft-get-balance newyorkcitycoin user))
+)
+
+(define-read-only (get-total-supply)
+  (ok (ft-get-supply newyorkcitycoin))
+)
+
+(define-read-only (get-token-uri)
+  (ok (var-get tokenUri))
+)
+
+;; TOKEN CONFIGURATION
+
+;; define bonus period and initial epoch length
+(define-constant TOKEN_BONUS_PERIOD u10000)
+(define-constant TOKEN_EPOCH_LENGTH u25000)
+
+;; once activated, activation cannot happen again
+(define-data-var tokenActivated bool false)
+
+;; core contract states
+(define-constant STATE_DEPLOYED u0)
+(define-constant STATE_ACTIVE u1)
+(define-constant STATE_INACTIVE u2)
+
+;; one-time function to activate the token
+(define-public (activate-token (coreContract principal) (stacksHeight uint))
+  (let
+    (
+      (coreContractMap (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2 get-core-contract-info coreContract)))
+      (threshold1 (+ stacksHeight TOKEN_BONUS_PERIOD TOKEN_EPOCH_LENGTH))         ;; 35,000 blocks
+      (threshold2 (+ stacksHeight TOKEN_BONUS_PERIOD (* u3 TOKEN_EPOCH_LENGTH)))  ;; 85,000 blocks
+      (threshold3 (+ stacksHeight TOKEN_BONUS_PERIOD (* u7 TOKEN_EPOCH_LENGTH)))  ;; 185,000 blocks
+      (threshold4 (+ stacksHeight TOKEN_BONUS_PERIOD (* u15 TOKEN_EPOCH_LENGTH))) ;; 385,000 blocks
+      (threshold5 (+ stacksHeight TOKEN_BONUS_PERIOD (* u31 TOKEN_EPOCH_LENGTH))) ;; 785,000 blocks
+    )
+    (asserts! (is-eq (get state coreContractMap) STATE_ACTIVE) ERR_UNAUTHORIZED)
+    (asserts! (not (var-get tokenActivated)) ERR_TOKEN_ALREADY_ACTIVATED)
+    (var-set tokenActivated true)
+    (try! (set-coinbase-thresholds threshold1 threshold2 threshold3 threshold4 threshold5))
+    (ok true)
+  )
+)
+
+;; COINBASE THRESHOLDS
+
+;; coinbase thresholds per halving, used to select coinbase rewards in core
+;; initially set by register-user in core contract per CCIP-008
+(define-data-var coinbaseThreshold1 uint u0)
+(define-data-var coinbaseThreshold2 uint u0)
+(define-data-var coinbaseThreshold3 uint u0)
+(define-data-var coinbaseThreshold4 uint u0)
+(define-data-var coinbaseThreshold5 uint u0)
+
+;; return coinbase thresholds if token activated
+(define-read-only (get-coinbase-thresholds)
+  (let
+    (
+      (activated (var-get tokenActivated))
+    )
+    (asserts! activated ERR_TOKEN_NOT_ACTIVATED)
+    (ok {
+      coinbaseThreshold1: (var-get coinbaseThreshold1),
+      coinbaseThreshold2: (var-get coinbaseThreshold2),
+      coinbaseThreshold3: (var-get coinbaseThreshold3),
+      coinbaseThreshold4: (var-get coinbaseThreshold4),
+      coinbaseThreshold5: (var-get coinbaseThreshold5)
+    })
+  )
+)
+
+(define-private (set-coinbase-thresholds (threshold1 uint) (threshold2 uint) (threshold3 uint) (threshold4 uint) (threshold5 uint))
+  (begin
+    ;; check that all thresholds increase in value
+    (asserts! (and (> threshold1 u0) (> threshold2 threshold1) (> threshold3 threshold2) (> threshold4 threshold3) (> threshold5 threshold4)) ERR_INVALID_COINBASE_THRESHOLD)
+    ;; set coinbase thresholds
+    (var-set coinbaseThreshold1 threshold1)
+    (var-set coinbaseThreshold2 threshold2)
+    (var-set coinbaseThreshold3 threshold3)
+    (var-set coinbaseThreshold4 threshold4)
+    (var-set coinbaseThreshold5 threshold5)
+    ;; print coinbase thresholds
+    (print {
+      coinbaseThreshold1: threshold1,
+      coinbaseThreshold2: threshold2,
+      coinbaseThreshold3: threshold3,
+      coinbaseThreshold4: threshold4,
+      coinbaseThreshold5: threshold5
+    })
+    (ok true)
+  )
+)
+
+;; only accessible by auth
+(define-public (update-coinbase-thresholds (threshold1 uint) (threshold2 uint) (threshold3 uint) (threshold4 uint) (threshold5 uint))
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (asserts! (var-get tokenActivated) ERR_TOKEN_NOT_ACTIVATED)
+    (try! (set-coinbase-thresholds threshold1 threshold2 threshold3 threshold4 threshold5))
+    (ok true)
+  )
+)
+
+;; COINBASE AMOUNTS (REWARDS)
+
+;; coinbase rewards per threshold per CCIP-008
+(define-data-var coinbaseAmountBonus uint (* MICRO_CITYCOINS u250000))
+(define-data-var coinbaseAmount1 uint (* MICRO_CITYCOINS u100000))
+(define-data-var coinbaseAmount2 uint (* MICRO_CITYCOINS u50000))
+(define-data-var coinbaseAmount3 uint (* MICRO_CITYCOINS u25000))
+(define-data-var coinbaseAmount4 uint (* MICRO_CITYCOINS u12500))
+(define-data-var coinbaseAmount5 uint (* MICRO_CITYCOINS u6250))
+(define-data-var coinbaseAmountDefault uint (* MICRO_CITYCOINS u3125))
+
+;; return coinbase thresholds if token activated
+(define-read-only (get-coinbase-amounts)
+  (ok {
+    coinbaseAmountBonus: (var-get coinbaseAmountBonus),
+    coinbaseAmount1: (var-get coinbaseAmount1),
+    coinbaseAmount2: (var-get coinbaseAmount2),
+    coinbaseAmount3: (var-get coinbaseAmount3),
+    coinbaseAmount4: (var-get coinbaseAmount4),
+    coinbaseAmount5: (var-get coinbaseAmount5),
+    coinbaseAmountDefault: (var-get coinbaseAmountDefault)
+  })
+)
+
+(define-private (set-coinbase-amounts (amountBonus uint) (amount1 uint) (amount2 uint) (amount3 uint) (amount4 uint) (amount5 uint) (amountDefault uint))
+  (begin
+    ;; check that all amounts are greater than zero
+    (asserts! (and (> amountBonus u0) (> amount1 u0) (> amount2 u0) (> amount3 u0) (> amount4 u0) (> amount5 u0) (> amountDefault u0)) ERR_INVALID_COINBASE_AMOUNT)
+    ;; set coinbase amounts in token contract
+    (var-set coinbaseAmountBonus amountBonus)
+    (var-set coinbaseAmount1 amount1)
+    (var-set coinbaseAmount2 amount2)
+    (var-set coinbaseAmount3 amount3)
+    (var-set coinbaseAmount4 amount4)
+    (var-set coinbaseAmount5 amount5)
+    (var-set coinbaseAmountDefault amountDefault)
+    ;; print coinbase amounts
+    (print {
+      coinbaseAmountBonus: amountBonus,
+      coinbaseAmount1: amount1,
+      coinbaseAmount2: amount2,
+      coinbaseAmount3: amount3,
+      coinbaseAmount4: amount4,
+      coinbaseAmount5: amount5,
+      coinbaseAmountDefault: amountDefault
+    })
+    (ok true)
+  )
+)
+
+;; only accessible by auth
+(define-public (update-coinbase-amounts (amountBonus uint) (amount1 uint) (amount2 uint) (amount3 uint) (amount4 uint) (amount5 uint) (amountDefault uint))
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    ;; (asserts! (var-get tokenActivated) ERR_TOKEN_NOT_ACTIVATED)
+    (try! (set-coinbase-amounts amountBonus amount1 amount2 amount3 amount4 amount5 amountDefault))
+    (ok true)
+  )
+)
+
+;; V1 TO V2 CONVERSION
+
+;; TESTNET: convert-to-v2 removed, no v1
+
+;; UTILITIES
+
+(define-data-var tokenUri (optional (string-utf8 256)) (some u"https://cdn.citycoins.co/metadata/newyorkcitycoin.json"))
+
+;; set token URI to new value, only accessible by Auth
+(define-public (set-token-uri (newUri (optional (string-utf8 256))))
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (ok (var-set tokenUri newUri))
+  )
+)
+
+;; mint new tokens, only accessible by a Core contract
+(define-public (mint (amount uint) (recipient principal))
+  (let
+    (
+      (coreContract (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2 get-core-contract-info contract-caller)))
+    )
+    (ft-mint? newyorkcitycoin amount recipient)
+  )
+)
+
+;; burn tokens
+(define-public (burn (amount uint) (owner principal))
+  (begin
+    (asserts! (is-eq tx-sender owner) ERR_UNAUTHORIZED)
+    (ft-burn? newyorkcitycoin amount owner)
+  )
+)
+
+;; checks if caller is Auth contract
+(define-private (is-authorized-auth)
+  (is-eq contract-caller 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2)
+)
+
+;; SEND-MANY
+
+(define-public (send-many (recipients (list 200 { to: principal, amount: uint, memo: (optional (buff 34)) })))
+  (fold check-err
+    (map send-token recipients)
+    (ok true)
+  )
+)
+
+(define-private (check-err (result (response bool uint)) (prior (response bool uint)))
+  (match prior ok-value
+    result
+    err-value (err err-value)
+  )
+)
+
+(define-private (send-token (recipient { to: principal, amount: uint, memo: (optional (buff 34)) }))
+  (send-token-with-memo (get amount recipient) (get to recipient) (get memo recipient))
+)
+
+(define-private (send-token-with-memo (amount uint) (to principal) (memo (optional (buff 34))))
+  (let
+    (
+      (transferOk (try! (transfer amount tx-sender to memo)))
+    )
+    (ok transferOk)
+  )
+)

--- a/contracts/legacy/newyorkcitycoin-token-v2.clar
+++ b/contracts/legacy/newyorkcitycoin-token-v2.clar
@@ -78,7 +78,7 @@
 (define-public (activate-token (coreContract principal) (stacksHeight uint))
   (let
     (
-      (coreContractMap (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2 get-core-contract-info coreContract)))
+      (coreContractMap (try! (contract-call? .newyorkcitycoin-auth-v2 get-core-contract-info coreContract)))
       (threshold1 (+ stacksHeight TOKEN_BONUS_PERIOD TOKEN_EPOCH_LENGTH))         ;; 35,000 blocks
       (threshold2 (+ stacksHeight TOKEN_BONUS_PERIOD (* u3 TOKEN_EPOCH_LENGTH)))  ;; 85,000 blocks
       (threshold3 (+ stacksHeight TOKEN_BONUS_PERIOD (* u7 TOKEN_EPOCH_LENGTH)))  ;; 185,000 blocks
@@ -232,7 +232,7 @@
 (define-public (mint (amount uint) (recipient principal))
   (let
     (
-      (coreContract (try! (contract-call? 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2 get-core-contract-info contract-caller)))
+      (coreContract (try! (contract-call? .newyorkcitycoin-auth-v2 get-core-contract-info contract-caller)))
     )
     (ft-mint? newyorkcitycoin amount recipient)
   )
@@ -248,7 +248,7 @@
 
 ;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
-  (is-eq contract-caller 'STSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1D64KKHQ.newyorkcitycoin-auth-v2)
+  (is-eq contract-caller .newyorkcitycoin-auth-v2)
 )
 
 ;; SEND-MANY

--- a/contracts/legacy/newyorkcitycoin-token-v2.clar
+++ b/contracts/legacy/newyorkcitycoin-token-v2.clar
@@ -3,7 +3,7 @@
 
 ;; TRAIT DEFINITIONS
 
-(impl-trait 'ST1XQXW9JNQ1W4A7PYTN3HCHPEY7SHM6KPA085ES6.citycoin-token-v2-trait.citycoin-token-v2)
+(impl-trait .citycoin-token-v2-trait.citycoin-token-v2)
 
 ;; ERROR CODES
 

--- a/models/extensions/ccd006-citycoin-mining.model.ts
+++ b/models/extensions/ccd006-citycoin-mining.model.ts
@@ -52,8 +52,8 @@ export class CCD006CityMining {
     return Tx.contractCall(this.name, "set-reward-delay", [types.uint(delay)], sender.address);
   }
 
-  setMiningStatus(sender: Account, status: boolean) {
-    return Tx.contractCall(this.name, "set-mining-status", [types.bool(status)], sender.address);
+  setMiningEnabled(sender: Account, status: boolean) {
+    return Tx.contractCall(this.name, "set-mining-enabled", [types.bool(status)], sender.address);
   }
 
   // Read only functions

--- a/models/extensions/ccd006-citycoin-mining.model.ts
+++ b/models/extensions/ccd006-citycoin-mining.model.ts
@@ -17,6 +17,7 @@ export enum ErrCode {
   ERR_NO_MINER_DATA,
   ERR_ALREADY_CLAIMED,
   ERR_MINER_NOT_WINNER,
+  ERR_MINING_DISABLED,
 }
 
 export class CCD006CityMining {
@@ -43,12 +44,16 @@ export class CCD006CityMining {
     return Tx.contractCall(this.name, "mine", [types.ascii(cityName), types.list(amounts.map((entry) => types.uint(entry)))], sender.address);
   }
 
+  claimMiningReward(sender: Account, cityName: string, claimHeight: number) {
+    return Tx.contractCall(this.name, "claim-mining-reward", [types.ascii(cityName), types.uint(claimHeight)], sender.address);
+  }
+
   setRewardDelay(sender: Account, delay: number) {
     return Tx.contractCall(this.name, "set-reward-delay", [types.uint(delay)], sender.address);
   }
 
-  claimMiningReward(sender: Account, cityName: string, claimHeight: number) {
-    return Tx.contractCall(this.name, "claim-mining-reward", [types.ascii(cityName), types.uint(claimHeight)], sender.address);
+  setMiningStatus(sender: Account, status: boolean) {
+    return Tx.contractCall(this.name, "set-mining-status", [types.bool(status)], sender.address);
   }
 
   // Read only functions
@@ -83,6 +88,10 @@ export class CCD006CityMining {
 
   getRewardDelay(): ReadOnlyFn {
     return this.callReadOnlyFn("get-reward-delay", []);
+  }
+
+  isMiningEnabled(): ReadOnlyFn {
+    return this.callReadOnlyFn("is-mining-enabled", []);
   }
 
   // Extension callback

--- a/models/extensions/ccd007-citycoin-stacking.model.ts
+++ b/models/extensions/ccd007-citycoin-stacking.model.ts
@@ -10,6 +10,7 @@ export enum ErrCode {
   ERR_INCOMPLETE_CYCLE,
   ERR_NOTHING_TO_CLAIM,
   ERR_PAYOUT_COMPLETE,
+  ERR_STACKING_DISABLED,
 }
 
 export class CCD007CityStacking {

--- a/models/extensions/ccd007-citycoin-stacking.model.ts
+++ b/models/extensions/ccd007-citycoin-stacking.model.ts
@@ -49,14 +49,15 @@ export class CCD007CityStacking {
   stack(sender: Account, cityName: string, amount: number, lockPeriod: number) {
     return Tx.contractCall(this.name, "stack", [types.ascii(cityName), types.uint(amount), types.uint(lockPeriod)], sender.address);
   }
-  /* disabled - function removed from ccd007
-  setRewardCycleLength(sender: Account, length: number) {
-    return Tx.contractCall(this.name, "set-reward-cycle-length", [types.uint(length)], sender.address);
+  setStackingStatus(sender: Account, status: boolean) {
+    return Tx.contractCall(this.name, "set-stacking-status", [types.bool(status)], sender.address);
   }
-  */
 
   // Read only functions
 
+  getStackingStatus(): ReadOnlyFn {
+    return this.callReadOnlyFn("get-stacking-status", []);
+  }
   getRewardCycleLength(): ReadOnlyFn {
     return this.callReadOnlyFn("get-reward-cycle-length", []);
   }

--- a/models/extensions/ccd007-citycoin-stacking.model.ts
+++ b/models/extensions/ccd007-citycoin-stacking.model.ts
@@ -55,8 +55,8 @@ export class CCD007CityStacking {
 
   // Read only functions
 
-  getStackingStatus(): ReadOnlyFn {
-    return this.callReadOnlyFn("get-stacking-status", []);
+  isStackingEnabled(): ReadOnlyFn {
+    return this.callReadOnlyFn("is-stacking-enabled", []);
   }
   getRewardCycleLength(): ReadOnlyFn {
     return this.callReadOnlyFn("get-reward-cycle-length", []);

--- a/models/extensions/ccd007-citycoin-stacking.model.ts
+++ b/models/extensions/ccd007-citycoin-stacking.model.ts
@@ -49,8 +49,8 @@ export class CCD007CityStacking {
   stack(sender: Account, cityName: string, amount: number, lockPeriod: number) {
     return Tx.contractCall(this.name, "stack", [types.ascii(cityName), types.uint(amount), types.uint(lockPeriod)], sender.address);
   }
-  setStackingStatus(sender: Account, status: boolean) {
-    return Tx.contractCall(this.name, "set-stacking-status", [types.bool(status)], sender.address);
+  setStackingEnabled(sender: Account, status: boolean) {
+    return Tx.contractCall(this.name, "set-stacking-enabled", [types.bool(status)], sender.address);
   }
 
   // Read only functions

--- a/tests/contracts/proposals/test-ccd006-citycoin-mining-005.clar
+++ b/tests/contracts/proposals/test-ccd006-citycoin-mining-005.clar
@@ -5,5 +5,5 @@
 (impl-trait .proposal-trait.proposal-trait)
 
 (define-public (execute (sender principal))
-  (contract-call? .ccd006-citycoin-mining set-mining-status false)
+  (contract-call? .ccd006-citycoin-mining set-mining-enabled false)
 )

--- a/tests/contracts/proposals/test-ccd006-citycoin-mining-005.clar
+++ b/tests/contracts/proposals/test-ccd006-citycoin-mining-005.clar
@@ -5,8 +5,5 @@
 (impl-trait .proposal-trait.proposal-trait)
 
 (define-public (execute (sender principal))
-	(begin
-		(try! (contract-call? .ccd007-citycoin-stacking set-stacking-status false))
-		(ok true)
-	)
+  (contract-call? .ccd006-citycoin-mining set-mining-status false)
 )

--- a/tests/contracts/proposals/test-ccd007-citycoin-stacking-012.clar
+++ b/tests/contracts/proposals/test-ccd007-citycoin-stacking-012.clar
@@ -1,0 +1,13 @@
+;; Title: Test Proposal
+;; Version: 1.0.0
+;; Synopsis: Test proposal for clarinet layer
+
+(impl-trait .proposal-trait.proposal-trait)
+
+(define-public (execute (sender principal))
+	(begin
+		(try! (contract-call? .base-dao set-extension .ccd007-citycoin-stacking false))
+		(try! (contract-call? .ccd007-citycoin-stacking set-claim-status true))
+		(ok true)
+	)
+)

--- a/tests/contracts/proposals/test-ccd007-citycoin-stacking-012.clar
+++ b/tests/contracts/proposals/test-ccd007-citycoin-stacking-012.clar
@@ -6,7 +6,7 @@
 
 (define-public (execute (sender principal))
 	(begin
-		(try! (contract-call? .ccd007-citycoin-stacking set-stacking-status false))
+		(try! (contract-call? .ccd007-citycoin-stacking set-stacking-enabled false))
 		(ok true)
 	)
 )

--- a/tests/contracts/proposals/test-ccd007-citycoin-stacking-012.clar
+++ b/tests/contracts/proposals/test-ccd007-citycoin-stacking-012.clar
@@ -6,8 +6,8 @@
 
 (define-public (execute (sender principal))
 	(begin
-		(try! (contract-call? .base-dao set-extension .ccd007-citycoin-stacking false))
-		(try! (contract-call? .ccd007-citycoin-stacking set-claim-status true))
+		;; (try! (contract-call? .base-dao set-extension .ccd007-citycoin-stacking false))
+		(try! (contract-call? .ccd007-citycoin-stacking set-stacking-status false))
 		(ok true)
 	)
 )

--- a/tests/extensions/ccd006-citycoin-mining.test.ts
+++ b/tests/extensions/ccd006-citycoin-mining.test.ts
@@ -1454,20 +1454,20 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "ccd006-citycoin-mining: set-mining-status() fails when called directly",
+  name: "ccd006-citycoin-mining: set-mining-enabled() fails when called directly",
   fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const sender = accounts.get("deployer")!;
     const ccd006CityMining = new CCD006CityMining(chain, sender, "ccd006-citycoin-mining");
     // act
-    const block = chain.mineBlock([ccd006CityMining.setMiningStatus(sender, true)]);
+    const block = chain.mineBlock([ccd006CityMining.setMiningEnabled(sender, true)]);
     // assert
     block.receipts[0].result.expectErr().expectUint(CCD006CityMining.ErrCode.ERR_UNAUTHORIZED);
   },
 });
 
 Clarinet.test({
-  name: "ccd006-citycoin-mining: get-mining-status() returns true after deployment",
+  name: "ccd006-citycoin-mining: get-mining-enabled() returns true after deployment",
   fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const sender = accounts.get("deployer")!;

--- a/tests/extensions/ccd006-citycoin-mining.test.ts
+++ b/tests/extensions/ccd006-citycoin-mining.test.ts
@@ -4,7 +4,8 @@
  * 1. mine
  * 2. claim-mining-reward
  * 3. reward-delay
- * 4. read-only functions
+ * 4. mining status
+ * 5. read-only functions
  */
 import { Account, assert, assertEquals, Clarinet, Chain, types } from "../../utils/deps.ts";
 import { constructAndPassProposal, EXTENSIONS, passProposal, PROPOSALS } from "../../utils/common.ts";
@@ -1301,7 +1302,36 @@ Clarinet.test({
 });
 
 // =============================
-// 4. READ-ONLY FUNCTIONS
+// 4. MINING STATUS
+// =============================
+
+Clarinet.test({
+  name: "ccd006-citycoin-mining: set-mining-status() fails when called directly",
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    // arrange
+    const sender = accounts.get("deployer")!;
+    const ccd006CityMining = new CCD006CityMining(chain, sender, "ccd006-citycoin-mining");
+    // act
+    const block = chain.mineBlock([ccd006CityMining.setMiningStatus(sender, true)]);
+    // assert
+    block.receipts[0].result.expectErr().expectUint(CCD006CityMining.ErrCode.ERR_UNAUTHORIZED);
+  },
+});
+
+Clarinet.test({
+  name: "ccd006-citycoin-mining: get-mining-status() returns true after deployment",
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    // arrange
+    const sender = accounts.get("deployer")!;
+    const ccd006CityMining = new CCD006CityMining(chain, sender, "ccd006-citycoin-mining");
+    // act
+    // assert
+    ccd006CityMining.isMiningEnabled().result.expectBool(true);
+  },
+});
+
+// =============================
+// 5. READ-ONLY FUNCTIONS
 // =============================
 
 Clarinet.test({

--- a/tests/extensions/ccd006-citycoin-mining.test.ts
+++ b/tests/extensions/ccd006-citycoin-mining.test.ts
@@ -1306,59 +1306,6 @@ Clarinet.test({
 // =============================
 
 Clarinet.test({
-  name: "ccd006-citycoin-mining: mine() succeeds and mines 1 block for 1 user",
-  fn(chain: Chain, accounts: Map<string, Account>) {
-    // arrange
-    const sender = accounts.get("deployer")!;
-    const user = accounts.get("wallet_1")!;
-    const ccd005CityData = new CCD005CityData(chain, sender, "ccd005-city-data");
-    const ccd006CityMining = new CCD006CityMining(chain, sender, "ccd006-citycoin-mining");
-
-    // act
-    const entries: number[] = [10];
-    constructAndPassProposal(chain, accounts, PROPOSALS.TEST_CCD004_CITY_REGISTRY_001);
-    passProposal(chain, accounts, PROPOSALS.TEST_CCD003_USER_REGISTRY_001);
-    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_001);
-    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_001);
-    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_002);
-    passProposal(chain, accounts, PROPOSALS.TEST_CCD006_CITY_MINING_002);
-    ccd005CityData.getCityTreasuryNonce(miaCityId).result.expectUint(1);
-    const block = chain.mineBlock([ccd006CityMining.mine(user, miaCityName, entries)]);
-
-    // assert
-    const firstBlock = block.height - 1;
-    const lastBlock = firstBlock;
-    const totalAmount = 10;
-    const totalBlocks = 1;
-    const userId = 1;
-
-    block.receipts[0].result.expectOk().expectBool(true);
-
-    block.receipts[0].events.expectSTXTransferEvent(10, user.address, `${sender.address}.${miaTreasuryName}`);
-    const expectedPrintMsg = `{cityId: u1, cityName: "mia", cityTreasury: ${sender.address}.${miaTreasuryName}, event: "mining", firstBlock: ${types.uint(firstBlock)}, lastBlock: ${types.uint(lastBlock)}, totalAmount: ${types.uint(totalAmount)}, totalBlocks: ${types.uint(totalBlocks)}, userId: ${types.uint(userId)}}`;
-    //console.log(block.receipts[0].events[1].contract_event.value)
-    //ccd006CityMining.isBlockWinner(miaCityId, user.address, firstBlock).result.expectBool(true)
-    const expectedStats2 = {
-      commit: types.uint(10),
-      high: types.uint(10),
-      low: types.uint(0),
-      winner: types.bool(false),
-    };
-    assertEquals(ccd006CityMining.getMinerAtBlock(miaCityId, firstBlock, userId).result.expectTuple(), expectedStats2);
-    const expectedStats = {
-      amount: types.uint(10),
-      claimed: types.bool(false),
-      miners: types.uint(1),
-    };
-    assertEquals(ccd006CityMining.getMiningStatsAtBlock(miaCityId, firstBlock).result.expectTuple(), expectedStats);
-    ccd006CityMining.getBlockWinner(miaCityId, firstBlock).result.expectNone();
-
-    block.receipts[0].events.expectPrintEvent(`${sender.address}.ccd006-citycoin-mining`, expectedPrintMsg);
-    block.receipts[0].result.expectOk().expectBool(true);
-  },
-});
-
-Clarinet.test({
   name: "ccd006-citycoin-mining: mine() fails if mining is disabled in the contract",
   fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
@@ -1395,10 +1342,114 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "ccd006-citycoin-mining: claim-mining-reward succeeds if mining is disabled in the contract",
+  name: "ccd006-citycoin-mining: claim-mining-reward() returns ERR_NO_MINER_DATA after mining is disabled if user did not mine in that block",
   fn(chain: Chain, accounts: Map<string, Account>) {
-    // TODO
-    // assertEquals("TODO", "a complete test");
+    // arrange
+    const sender = accounts.get("deployer")!;
+    const user = accounts.get("wallet_1")!;
+    const ccd006CityMining = new CCD006CityMining(chain, sender, "ccd006-citycoin-mining");
+
+    // act
+    constructAndPassProposal(chain, accounts, PROPOSALS.TEST_CCD004_CITY_REGISTRY_001);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_001);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_002);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD003_USER_REGISTRY_001);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD006_CITY_MINING_005);
+    const claimHeight = 6; // one less than actual bh
+    chain.mineEmptyBlock(rewardDelay);
+    const block = chain.mineBlock([ccd006CityMining.claimMiningReward(user, miaCityName, claimHeight)]);
+
+    // assert
+    ccd006CityMining.getRewardDelay().result.expectUint(rewardDelay);
+    block.receipts[0].result.expectErr().expectUint(CCD006CityMining.ErrCode.ERR_NO_MINER_DATA);
+  },
+});
+
+Clarinet.test({
+  name: "ccd006-citycoin-mining: claim-mining-reward() succeeds after mining is disabled",
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    // arrange
+    const sender = accounts.get("deployer")!;
+    const user1 = accounts.get("wallet_1")!;
+    const user2 = accounts.get("wallet_2")!;
+    const ccd005CityData = new CCD005CityData(chain, sender, "ccd005-city-data");
+    const ccd006CityMining = new CCD006CityMining(chain, sender, "ccd006-citycoin-mining");
+    const totalAmount = 10;
+    const totalBlocks = 1;
+    const entries: number[] = [10];
+
+    // act
+    constructAndPassProposal(chain, accounts, PROPOSALS.TEST_CCD004_CITY_REGISTRY_001);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_001);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_002);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_009);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_010);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_018);
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD006_CITY_MINING_002);
+    ccd005CityData.getCityTreasuryNonce(miaCityId).result.expectUint(1);
+
+    const miningBlock = chain.mineBlock([ccd006CityMining.mine(user1, miaCityName, entries), ccd006CityMining.mine(user2, miaCityName, entries)]);
+    // console.log(JSON.stringify(miningBlock, null, 2));
+    const claimHeight = miningBlock.height - 1;
+    const lastBlock = claimHeight + totalBlocks - 1;
+    chain.mineEmptyBlock(rewardDelay + 1);
+
+    // disable mining
+    passProposal(chain, accounts, PROPOSALS.TEST_CCD006_CITY_MINING_005);
+
+    const miningClaimBlock = chain.mineBlock([ccd006CityMining.claimMiningReward(user1, miaCityName, claimHeight), ccd006CityMining.claimMiningReward(user2, miaCityName, claimHeight)]);
+
+    // assert
+
+    const coinbaseInfo = ccd005CityData.getCityCoinbaseInfo(miaCityId).result.expectTuple();
+    // verify coinbase amounts
+    const expectedAmounts = {
+      cbaBonus: types.uint(10),
+      cba1: types.uint(100),
+      cba2: types.uint(1000),
+      cba3: types.uint(10000),
+      cba4: types.uint(100000),
+      cba5: types.uint(1000000),
+      cbaDefault: types.uint(10000000),
+    };
+    assertEquals(coinbaseInfo.amounts.expectSome().expectTuple(), expectedAmounts);
+    // verify coinbase thresholds
+    const expectedThresholds = {
+      cbt1: types.uint(50),
+      cbt2: types.uint(60),
+      cbt3: types.uint(70),
+      cbt4: types.uint(80),
+      cbt5: types.uint(90),
+    };
+    assertEquals(coinbaseInfo.thresholds.expectSome().expectTuple(), expectedThresholds);
+
+    miningBlock.receipts[0].result.expectOk().expectBool(true);
+    miningBlock.receipts[1].result.expectOk().expectBool(true);
+
+    if (miningClaimBlock.receipts[0].result === "(err u6010)") {
+      //console.log("USER 2 WINS");
+      miningClaimBlock.receipts[0].result.expectErr().expectUint(CCD006CityMining.ErrCode.ERR_ALREADY_CLAIMED);
+      miningClaimBlock.receipts[1].result.expectOk().expectBool(true);
+    } else {
+      //console.log("USER 1 WINS");
+      miningClaimBlock.receipts[0].result.expectOk().expectBool(true);
+      miningClaimBlock.receipts[1].result.expectErr().expectUint(CCD006CityMining.ErrCode.ERR_ALREADY_CLAIMED);
+    }
+
+    miningBlock.receipts[0].events.expectSTXTransferEvent(10, user1.address, `${sender.address}.${miaTreasuryName}`);
+    miningBlock.receipts[1].events.expectSTXTransferEvent(10, user2.address, `${sender.address}.${miaTreasuryName}`);
+    // {cityId: u1, cityName: \"mia\", cityTreasury: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.ccd002-treasury-mia-mining, event: \"mining\", firstBlock: u10, lastBlock: u10, totalAmount: u10, totalBlocks: u1, userId: u1}"}
+    let expectedPrintMsg = `{cityId: u1, cityName: "mia", cityTreasury: ${sender.address}.${miaTreasuryName}, event: "mining", firstBlock: ${types.uint(claimHeight)}, lastBlock: ${types.uint(lastBlock)}, totalAmount: ${types.uint(totalAmount)}, totalBlocks: ${types.uint(totalBlocks)}, userId: ${types.uint(1)}}`;
+    // console.log(JSON.stringify(miningBlock.receipts[0].events), null, 2);
+    miningBlock.receipts[0].events.expectPrintEvent(`${sender.address}.ccd006-citycoin-mining`, expectedPrintMsg);
+    expectedPrintMsg = `{cityId: u1, cityName: "mia", cityTreasury: ${sender.address}.${miaTreasuryName}, event: "mining", firstBlock: ${types.uint(claimHeight)}, lastBlock: ${types.uint(lastBlock)}, totalAmount: ${types.uint(totalAmount)}, totalBlocks: ${types.uint(totalBlocks)}, userId: ${types.uint(2)}}`;
+    miningBlock.receipts[1].events.expectPrintEvent(`${sender.address}.ccd006-citycoin-mining`, expectedPrintMsg);
+
+    //dumpMiningData(ccd006CityMining, miaCityId, (firstBlock), (1), miningStatsAt, minerAt);
+    ccd006CityMining.getRewardDelay().result.expectUint(rewardDelay);
+
+    //ccd006CityMining.getBlockWinner(miaCityId, firstBlock).result.expectUint(2);
+    ccd006CityMining.getBlockWinner(miaCityId, claimHeight).result.expectSome().expectUint(1);
   },
 });
 

--- a/tests/extensions/ccd006-citycoin-mining.test.ts
+++ b/tests/extensions/ccd006-citycoin-mining.test.ts
@@ -1306,6 +1306,22 @@ Clarinet.test({
 // =============================
 
 Clarinet.test({
+  name: "ccd006-citycoin-mining: mine() fails if mining is disabled in the contract",
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    // TODO
+    assertEquals("TODO", "a complete test");
+  },
+});
+
+Clarinet.test({
+  name: "ccd006-citycoin-mining: claim-mining-reward succeeds if mining is disabled in the contract",
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    // TODO
+    assertEquals("TODO", "a complete test");
+  },
+});
+
+Clarinet.test({
   name: "ccd006-citycoin-mining: set-mining-status() fails when called directly",
   fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange

--- a/tests/extensions/ccd007-citycoin-stacking.test.ts
+++ b/tests/extensions/ccd007-citycoin-stacking.test.ts
@@ -3,7 +3,7 @@
  * 0. AUTHORIZATION CHECKS
  * 1. stack
  * 2. claim-stacking-reward
- * 3. set-stacking-status
+ * 3. stacking-status
  */
 import { Account, assertEquals, Clarinet, Chain, types } from "../../utils/deps.ts";
 import { constructAndPassProposal, EXTENSIONS, passProposal, PROPOSALS } from "../../utils/common.ts";
@@ -936,7 +936,7 @@ Clarinet.test({
 });
 
 // =============================
-// 3. set-stacking-status
+// 3. stacking-status
 // =============================
 
 Clarinet.test({
@@ -949,5 +949,17 @@ Clarinet.test({
     const block = chain.mineBlock([ccd007CityStacking.setStackingStatus(sender, true)]);
     // assert
     block.receipts[0].result.expectErr().expectUint(CCD007CityStacking.ErrCode.ERR_UNAUTHORIZED);
+  },
+});
+
+Clarinet.test({
+  name: "ccd007-citycoin-stacking: get-stacking-status() returns true after deployment",
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    // arrange
+    const sender = accounts.get("deployer")!;
+    const ccd007CityStacking = new CCD007CityStacking(chain, sender, "ccd007-citycoin-stacking");
+    // act
+    // assert
+    ccd007CityStacking.getStackingStatus().result.expectBool(true);
   },
 });

--- a/tests/extensions/ccd007-citycoin-stacking.test.ts
+++ b/tests/extensions/ccd007-citycoin-stacking.test.ts
@@ -3,6 +3,7 @@
  * 0. AUTHORIZATION CHECKS
  * 1. stack
  * 2. claim-stacking-reward
+ * 3. set-stacking-status
  */
 import { Account, assertEquals, Clarinet, Chain, types } from "../../utils/deps.ts";
 import { constructAndPassProposal, EXTENSIONS, passProposal, PROPOSALS } from "../../utils/common.ts";
@@ -931,5 +932,22 @@ Clarinet.test({
     for (let i = 0; i < 10; i++) {
       ccd007CityStacking.getFirstBlockInRewardCycle(i).result.expectUint(CCD007CityStacking.REWARD_CYCLE_LENGTH * i + CCD007CityStacking.FIRST_STACKING_BLOCK);
     }
+  },
+});
+
+// =============================
+// 3. set-stacking-status
+// =============================
+
+Clarinet.test({
+  name: "ccd007-citycoin-stacking: set-stacking-status() fails when called directly",
+  fn(chain: Chain, accounts: Map<string, Account>) {
+    // arrange
+    const sender = accounts.get("deployer")!;
+    const ccd007CityStacking = new CCD007CityStacking(chain, sender, "ccd007-citycoin-stacking");
+    // act
+    const block = chain.mineBlock([ccd007CityStacking.setStackingStatus(sender, true)]);
+    // assert
+    block.receipts[0].result.expectErr().expectUint(CCD007CityStacking.ErrCode.ERR_UNAUTHORIZED);
   },
 });

--- a/tests/extensions/ccd007-citycoin-stacking.test.ts
+++ b/tests/extensions/ccd007-citycoin-stacking.test.ts
@@ -940,13 +940,13 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "ccd007-citycoin-stacking: set-stacking-status() fails when called directly",
+  name: "ccd007-citycoin-stacking: set-stacking-enabled() fails when called directly",
   fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange
     const sender = accounts.get("deployer")!;
     const ccd007CityStacking = new CCD007CityStacking(chain, sender, "ccd007-citycoin-stacking");
     // act
-    const block = chain.mineBlock([ccd007CityStacking.setStackingStatus(sender, true)]);
+    const block = chain.mineBlock([ccd007CityStacking.setStackingEnabled(sender, true)]);
     // assert
     block.receipts[0].result.expectErr().expectUint(CCD007CityStacking.ErrCode.ERR_UNAUTHORIZED);
   },

--- a/tests/extensions/ccd011-stacking-payouts.test.ts
+++ b/tests/extensions/ccd011-stacking-payouts.test.ts
@@ -85,32 +85,6 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "ccd011-stacking-payouts: send-stacking-reward() fails if treasury is not set",
-  fn(chain: Chain, accounts: Map<string, Account>) {
-    // arrange
-    const sender = accounts.get("wallet_2")!;
-    const amount = 1000000000;
-    const ccd011StackingPayouts = new CCD011StackingPayouts(chain, sender, "ccd011-stacking-payouts");
-
-    // act
-    // register MIA/NYC
-    constructAndPassProposal(chain, accounts, PROPOSALS.TEST_CCD004_CITY_REGISTRY_001);
-    // set activation details
-    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_001);
-    // set activation status: true
-    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_002);
-    // set pool operator to wallet_2
-    passProposal(chain, accounts, PROPOSALS.TEST_CCD007_CITY_STACKING_001);
-    // passProposal(chain, accounts, PROPOSALS.TEST_CCD007_CITY_STACKING_007);
-    const block = chain.mineBlock([ccd011StackingPayouts.sendStackingRewardMia(sender, 1, amount)]);
-    // assert
-    //console.log(`pool operator: ${ccd011StackingPayouts.getPoolOperator().result}`);
-    //console.log(`block:\n${JSON.stringify(block, null, 2)}}`);
-    block.receipts[0].result.expectErr().expectUint(CCD007CityStacking.ErrCode.ERR_INVALID_TREASURY);
-  },
-});
-
-Clarinet.test({
   name: "ccd011-stacking-payouts: send-stacking-reward() fails if not called by pool operator",
   fn(chain: Chain, accounts: Map<string, Account>) {
     // arrange

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -81,6 +81,7 @@ export const PROPOSALS = {
   TEST_CCD007_CITY_STACKING_009: ADDRESS.concat(".test-ccd007-citycoin-stacking-009"),
   TEST_CCD007_CITY_STACKING_010: ADDRESS.concat(".test-ccd007-citycoin-stacking-010"),
   TEST_CCD007_CITY_STACKING_011: ADDRESS.concat(".test-ccd007-citycoin-stacking-011"),
+  TEST_CCD007_CITY_STACKING_012: ADDRESS.concat(".test-ccd007-citycoin-stacking-012"),
   TEST_CCD011_STACKING_PAYOUTS_001: ADDRESS.concat(".test-ccd011-stacking-payouts-001"),
 };
 

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -73,6 +73,7 @@ export const PROPOSALS = {
   TEST_CCD006_CITY_MINING_002: ADDRESS.concat(".test-ccd006-citycoin-mining-002"),
   TEST_CCD006_CITY_MINING_003: ADDRESS.concat(".test-ccd006-citycoin-mining-003"),
   TEST_CCD006_CITY_MINING_004: ADDRESS.concat(".test-ccd006-citycoin-mining-004"),
+  TEST_CCD006_CITY_MINING_005: ADDRESS.concat(".test-ccd006-citycoin-mining-005"),
   TEST_CCD007_CITY_STACKING_001: ADDRESS.concat(".test-ccd007-citycoin-stacking-001"),
   TEST_CCD007_CITY_STACKING_002: ADDRESS.concat(".test-ccd007-citycoin-stacking-002"),
   TEST_CCD007_CITY_STACKING_003: ADDRESS.concat(".test-ccd007-citycoin-stacking-003"),


### PR DESCRIPTION
Following the changes in the last few PRs, a new set of contracts were deployed to testnet ([documented here](https://docs.google.com/spreadsheets/d/1DlcSOZaUhCDKImoHkR5fRN4tVl8J02WhNfGEzn4ghow/edit?usp=sharing)), and a few of the local contracts from [citycoins/contracts](https://github.com/citycoins/contracts) were ported over.

Both the legacy protocol and new DAO have the same deployer on testnet, and as a result, the local contracts can use sugared syntax for both devnet and testnet.

This also adds a new variable and related functions in ccd007 for allowing future cycle claims, more detail in 9b198bc.

Note: this pins Clarinet to version 1.4.2 until #55 is merged.