### PR TITLE
fix: proposal to fix test block height sensitivity

### DIFF
--- a/tests/extensions/ccd006-citycoin-mining.test.ts
+++ b/tests/extensions/ccd006-citycoin-mining.test.ts
@@ -815,9 +815,9 @@ Clarinet.test({
 
     // act
     constructAndPassProposal(chain, accounts, PROPOSALS.TEST_CCD004_CITY_REGISTRY_001);
-    passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_001);
+    const claimBlock = passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_001);
     passProposal(chain, accounts, PROPOSALS.TEST_CCD005_CITY_DATA_002);
-    const claimHeight = 7;
+    const claimHeight = claimBlock.height;
     chain.mineEmptyBlock(rewardDelay - 1);
     const block = chain.mineBlock([ccd006CityMining.claimMiningReward(sender, miaCityName, claimHeight)]);
 
@@ -1274,7 +1274,7 @@ Clarinet.test({
     const ccd006CityMining = new CCD006CityMining(chain, sender, "ccd006-citycoin-mining");
 
     // act
-    const receipts = constructAndPassProposal(chain, accounts, PROPOSALS.TEST_CCD006_CITY_MINING_004);
+    const receipts = constructAndPassProposal(chain, accounts, PROPOSALS.TEST_CCD006_CITY_MINING_004).receipts;
 
     // assert
     ccd006CityMining.getRewardDelay().result.expectUint(100);
@@ -1291,7 +1291,7 @@ Clarinet.test({
     ccd006CityMining.getRewardDelay().result.expectUint(100);
 
     // act
-    const receipts = constructAndPassProposal(chain, accounts, PROPOSALS.TEST_CCD006_CITY_MINING_003);
+    const receipts = constructAndPassProposal(chain, accounts, PROPOSALS.TEST_CCD006_CITY_MINING_003).receipts;
 
     // assert
     ccd006CityMining.getRewardDelay().result.expectUint(50);

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -106,7 +106,7 @@ export const passProposal = (chain: Chain, accounts: Map<string, Account>, propo
   // console.log(`passProposal at height: ${block.height}`);
   // console.log(`proposal: ${proposal}`);
   // console.log(`block:\n${JSON.stringify(block, null, 2)}`);
-  return block.receipts;
+  return block;
 };
 
 export const constructAndPassProposal = (chain: Chain, accounts: Map<string, Account>, proposal: string): any => {
@@ -120,5 +120,5 @@ export const constructAndPassProposal = (chain: Chain, accounts: Map<string, Acc
   // console.log(`constructAndPassProposal at height: ${block.height}`);
   // console.log(`proposal: ${proposal}`);
   // console.log(`block:\n${JSON.stringify(block, null, 2)}`);
-  return block.receipts;
+  return block;
 };


### PR DESCRIPTION
In the upcoming release of Clarinet 1.5.0, the deployment of your contracts may slightly change. This is because Clarinet now takes into account the epoch in which a requirement contract should be deployed, and uses that in simnet (console and test) and devnet (integrate). The project's contracts will default to the current epoch, 2.05, if none is specified in the Clarinet.toml file. 

This change exposed a few tests that are sensitive to block height changes. This PR offers a proposed fix for one of them. The two remaining failures are:

```
error: Error: Expected ok, got (err u6013)
    throw new Error(
          ^
    at consume (https://deno.land/x/clarinet@v1.4.0/index.ts:524:11)
    at String.expectOk (https://deno.land/x/clarinet@v1.4.0/index.ts:537:10)
    at Object.fn (file:///Users/brice/work/citycoins/protocol/tests/extensions/ccd006-citycoin-mining.test.ts:1144:43)
    at fn (https://deno.land/x/clarinet@v1.4.0/index.ts:304:23)

ccd006-citycoin-mining: claim-mining-reward() fails if user claims at incorrect height => https://deno.land/x/clarinet@v1.4.0/index.ts:262:10
error: Error: Expected ok, got (err u6015)
    throw new Error(
          ^
    at consume (https://deno.land/x/clarinet@v1.4.0/index.ts:524:11)
    at String.expectOk (https://deno.land/x/clarinet@v1.4.0/index.ts:537:10)
    at Object.fn (file:///Users/brice/work/citycoins/protocol/tests/extensions/ccd006-citycoin-mining.test.ts:1243:41)
    at fn (https://deno.land/x/clarinet@v1.4.0/index.ts:304:23)

 FAILURES 

ccd006-citycoin-mining: claim-mining-reward() user makes successful claim => https://deno.land/x/clarinet@v1.4.0/index.ts:262:10
ccd006-citycoin-mining: claim-mining-reward() fails if user claims at incorrect height => https://deno.land/x/clarinet@v1.4.0/index.ts:262:10

FAILED | 38 passed | 2 failed (9s)
```