### PR TITLE
Pin clarinet version 1.8.0

### DIFF
--- a/.github/workflows/test-contracts.yaml
+++ b/.github/workflows/test-contracts.yaml
@@ -25,11 +25,11 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v3
       - name: "Check contract syntax"
-        uses: docker://hirosystems/clarinet:v1.8.0
+        uses: docker://hirosystems/clarinet:1.8.0
         with:
           args: check
       - name: "Run all contract tests"
-        uses: docker://hirosystems/clarinet:v1.8.0
+        uses: docker://hirosystems/clarinet:1.8.0
         with:
           args: test --coverage
       - name: "Upload code coverage"

--- a/.github/workflows/test-contracts.yaml
+++ b/.github/workflows/test-contracts.yaml
@@ -25,11 +25,11 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v3
       - name: "Check contract syntax"
-        uses: docker://hirosystems/clarinet:latest
+        uses: docker://hirosystems/clarinet:v1.8.0
         with:
           args: check
       - name: "Run all contract tests"
-        uses: docker://hirosystems/clarinet:latest
+        uses: docker://hirosystems/clarinet:v1.8.0
         with:
           args: test --coverage
       - name: "Upload code coverage"


### PR DESCRIPTION
[Version 2.x](https://github.com/hirosystems/clarinet/releases/tag/v2.0.0) introduces a breaking change where clarinet test is deprecated in favor of the Clarinet JS SDK.